### PR TITLE
Add lower-precision integer and floating point data types, and packbits codec

### DIFF
--- a/codecs/packbits/README.md
+++ b/codecs/packbits/README.md
@@ -1,7 +1,7 @@
 # packbits codec
 
 Defines an `array -> bytes` codec that packs together values that are
-represented by a fixed number of bits that is not a multiple of 8.
+represented by a fixed number of bits that is not necessarily a multiple of 8.
 
 ## Codec name
 
@@ -15,9 +15,9 @@ Specifies how the number of padding bits is encoded, such that the number of
 decoded elements may be determined from the encoded representation alone.
 
 Must be one of:
-- `"start_byte"`, indicating that the first byte specifies the number of padding
+- `"first_byte"`, indicating that the first byte specifies the number of padding
   bits that were added;
-- `"end_byte"`, indicating that the final byte specifies the number of padding
+- `"last_byte"`, indicating that the final byte specifies the number of padding
   bits that were added;
 - `"none"` (default), indicating that the number of padding bits is not encoded.
   In this case, the number of decoded elements cannot be determined from the
@@ -28,25 +28,70 @@ elements from the encoded representation alone, because this information can be
 propagated from the metadata through any prior codecs in the chain, it may still
 be useful as an additional sanity check or for non-zarr uses of the codec.
 
-A value of `"start_byte"` provides compatibility with the [numcodecs packbits
+A value of `"first_byte"` provides compatibility with the [numcodecs packbits
 codec](https://github.com/zarr-developers/numcodecs/blob/3c933cf19d4d84f2efc5f3a36926d8c569514a90/numcodecs/packbits.py#L7)
 defined for zarr v2 (which only supports `bool`).
+
+### `first_bit` (Optional)
+
+Specifies the index (starting from the least-significant bit) of the first bit
+to be encoded.  If omitted, or specified as `null`, defaults to `0`.
+
+### `last_bit` (Optional)
+
+Specifies the index (starting from the least-significant bit) of the (inclusive)
+last bit to be encoded. If omitted, or specified as `null`, defaults to `N - 1`,
+where `N` is the total number of bits per component of the data type (specified
+below).
+
+It is invalid for `last_bit` to be less than `first_bit`.
+
+Note: for complex number data types, `first_bit` and `last_bit` apply to the
+real and imaginary coefficients separately.
 
 ## Format and algorithm
 
 This is an `array -> bytes` codec.
 
-- Each element of the array is encoded as a fixed number of bits, `k`.
+### Encoding/decoding of individual array elements
+
+Each element of the array is encoded as a fixed number of bits, `k`, where `k`
+is determined from the data type, `first_bit`, and `last_bit`. Specifically
+
+```
+b := last_bit - first_bit + 1,
+k := num_components * b,
+```
+
+where `num_components` is determined by the data type (2 for complex number data
+types, 1 for all other data types).
+
+Note: If `first_bit` and `last_bit` are both unspecified, `b == N`.
+
+Logically, to encode an element of the array, each component is first encoded as
+an `N`-bit value (retaining all bits). From this `N`-bit value, the `b` bits
+from `first_bit` to `last_bit` are then extracted.
+
+To decode an element of the array, the `b` encoded bits are first shifted to
+`first_bit`.  Depending on the data type, the value is then:
+
+- sign-extended (for signed integer data types), or
+- zero-extended (all other data types)
+
+up to `N` bits.
+
+### Encoding and decoding multiple
+
 - Array elements are encoded in lexicographical order, to produce a bit
   sequence; element `i` corresponds to bits `[i * k, (i+1) * k)` within the
   sequence.
 - The bit sequence is padded with 0 bits to ensure its length is a multiple of
   8 bits.
 - Encoded byte `i` corresponds to bits `[i * 8, (i+1) * 8)` within the sequence.
-- If `padding_encoding` is `"start_byte"`, a single byte specifying
+- If `padding_encoding` is `"first_byte"`, a single byte specifying
   the number of padding bits that were added is prepended to the encoded byte
   sequence.
-- If `padding_encoding` is `"end_byte"`, a single byte specifying the number of
+- If `padding_encoding` is `"last_byte"`, a single byte specifying the number of
   padding bits that were added is appended to the encoded byte sequence.
 
 ## Supported data types
@@ -55,8 +100,15 @@ This is an `array -> bytes` codec.
 - int2, uint2 (encoded as 2 bits)
 - int4, uint4, float4_e2m1fn (encoded as 4 bits)
 - float6_e2m3fn, float6_e3m2fn (encoded as 6 bits)
-- complex_float4_e2m1fn (encoded as 8 bits)
-- complex_float6_e2m3fn, complex_float6_e3m2fn (encoded as 12 bits)
+- complex_float4_e2m1fn (encoded as 2 4-bit components)
+- complex_float6_e2m3fn, complex_float6_e3m2fn (encoded as 2 6-bit components)
+- int8, uint8, int16, uint16, int32, uint32, int64, uint64, float32, float64,
+  bfloat16, complex_float32, complex_float64, complex_bfloat16 (encoded using
+  their little-endian representation as with the "bytes" codec)
+
+  Note: For these types, if `first_bit` and `last_bit` are not used to limit the
+  number of bits that are encoded, this codec does not provide any benefit over
+  the `"bytes"` codec but is supported nonetheless for uniformity.
 
 ## Change log
 

--- a/codecs/packbits/README.md
+++ b/codecs/packbits/README.md
@@ -1,0 +1,67 @@
+# packbits codec
+
+Defines an `array -> bytes` codec that packs together values that are
+represented by a fixed number of bits that is not a multiple of 8.
+
+## Codec name
+
+The value of the `name` member in the codec object MUST be `packbits`.
+
+## Configuration parameters
+
+### `padding_encoding` (Optional)
+
+Specifies how the number of padding bits is encoded, such that the number of
+decoded elements may be determined from the encoded representation alone.
+
+Must be one of:
+- `"start_byte"`, indicating that the first byte specifies the number of padding
+  bits that were added;
+- `"end_byte"`, indicating that the final byte specifies the number of padding
+  bits that were added;
+- `"none"` (default), indicating that the number of padding bits is not encoded.
+  In this case, the number of decoded elements cannot be determined from the
+  encoded representation alone.
+
+While zarr itself does not need to be able to recover the number of decoded
+elements from the encoded representation alone, because this information can be
+propagated from the metadata through any prior codecs in the chain, it may still
+be useful as an additional sanity check or for non-zarr uses of the codec.
+
+A value of `"start_byte"` provides compatibility with the [numcodecs packbits
+codec](https://github.com/zarr-developers/numcodecs/blob/3c933cf19d4d84f2efc5f3a36926d8c569514a90/numcodecs/packbits.py#L7)
+defined for zarr v2 (which only supports `bool`).
+
+## Format and algorithm
+
+This is an `array -> bytes` codec.
+
+- Each element of the array is encoded as a fixed number of bits, `k`.
+- Array elements are encoded in lexicographical order, to produce a bit
+  sequence; element `i` corresponds to bits `[i * k, (i+1) * k)` within the
+  sequence.
+- The bit sequence is padded with 0 bits to ensure its length is a multiple of
+  8 bits.
+- Encoded byte `i` corresponds to bits `[i * 8, (i+1) * 8)` within the sequence.
+- If `padding_encoding` is `"start_byte"`, a single byte specifying
+  the number of padding bits that were added is prepended to the encoded byte
+  sequence.
+- If `padding_encoding` is `"end_byte"`, a single byte specifying the number of
+  padding bits that were added is appended to the encoded byte sequence.
+
+## Supported data types
+
+- bool (encoded as 1 bit)
+- int2, uint2 (encoded as 2 bits)
+- int4, uint4, float4_e2m1fn (encoded as 4 bits)
+- float6_e2m3fn, float6_e3m2fn (encoded as 6 bits)
+- complex_float4_e2m1fn (encoded as 8 bits)
+- complex_float6_e2m3fn, complex_float6_e3m2fn (encoded as 12 bits)
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/codecs/packbits/schema.json
+++ b/codecs/packbits/schema.json
@@ -11,6 +11,24 @@
         "padding_encoding": {
           "enum": ["start_byte", "end_byte", "none"],
           "default": "none"
+        },
+        "start_bit": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            { "const": null }
+          ]
+        },
+        "end_bit": {
+          "oneOf": [
+            {
+              "type": "integer",
+              "minimum": 0
+            },
+            { "const": null }
+          ]
         }
       },
       "additionalProperties": false

--- a/codecs/packbits/schema.json
+++ b/codecs/packbits/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "const": "packbits"
+    },
+    "configuration": {
+      "type": "object",
+      "properties": {
+        "padding_encoding": {
+          "enum": ["start_byte", "end_byte", "none"],
+          "default": "none"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}

--- a/data-types/bfloat16/README.md
+++ b/data-types/bfloat16/README.md
@@ -1,0 +1,43 @@
+# bfloat16 data type
+
+Defines the `bfloat16` floating-point data type
+(https://en.wikipedia.org/wiki/Bfloat16_floating-point_format).
+
+A `bfloat16` number is a IEEE 754 binary32 floating-point number truncated at
+16-bits.
+
+- 1 sign bit
+- 8 exponent bits, with bias of 127
+- 7 mantissa bits
+- IEEE 754-compliant, with NaN and +/-inf.
+- Subnormal numbers when biased exponent is 0.
+
+## Data type name
+
+The data type is specified as `"bfloat16"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+The constant `"NaN"` corresponds to a representation of `"0x7fc0"`.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 2-byte little-endian or big-endian value `0bSEEEEEEEEMMMMMMM`.
+
+## See also
+
+A Python implementation is available at https://pypi.org/project/ml-dtypes/
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/bfloat16/schema.json
+++ b/data-types/bfloat16/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "bfloat16"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "bfloat16"
+    }
+  ]
+}

--- a/data-types/complex_bfloat16/README.md
+++ b/data-types/complex_bfloat16/README.md
@@ -1,0 +1,28 @@
+# complex_bfloat16 data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `bfloat16` data type.
+
+## Data type name
+
+The data type is specified as `"complex_bfloat16"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 2-byte
+little-endian or big-endian values.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_bfloat16/schema.json
+++ b/data-types/complex_bfloat16/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "complex_bfloat16"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "complex_bfloat16"
+    }
+  ]
+}

--- a/data-types/complex_float16/README.md
+++ b/data-types/complex_float16/README.md
@@ -1,0 +1,28 @@
+# complex_float16 data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float16` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float16"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 2-byte
+little-endian or big-endian values.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float16/schema.json
+++ b/data-types/complex_float16/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "complex_float16"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "complex_float16"
+    }
+  ]
+}

--- a/data-types/complex_float32/README.md
+++ b/data-types/complex_float32/README.md
@@ -1,0 +1,16 @@
+# complex_float32 data type
+
+Defines an alias of the core `complex64` data type, for consistency with the new
+complex number data types for which `complexNNN` naming is not sufficient.
+
+## Data type name
+
+The data type is specified as `"complex_float32"`.
+
+## Configuration
+
+None.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float32/schema.json
+++ b/data-types/complex_float32/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "complex_float32"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "complex_float32"
+    }
+  ]
+}

--- a/data-types/complex_float4_e2m1fn/README.md
+++ b/data-types/complex_float4_e2m1fn/README.md
@@ -1,0 +1,34 @@
+# complex_float4_e2m1fn data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float4_e2m1fn` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float4_e2m1fn"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float4_e2m1fn` data type. The `"endian"`
+parameter has no effect.
+
+### packbits
+
+Encoded as 2 consecutive (real component followed by imaginary component) 4-bit
+values, each encoded as specified by the `float4_e2m1fn` data type.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float4_e2m1fn/schema.json
+++ b/data-types/complex_float4_e2m1fn/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e8m0fnu"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e8m0fnu"
+    }
+  ]
+}

--- a/data-types/complex_float64/README.md
+++ b/data-types/complex_float64/README.md
@@ -1,0 +1,16 @@
+# complex_float64 data type
+
+Defines an alias of the core `complex128` data type, for consistency with the new
+complex number data types for which `complexNNN` naming is not sufficient.
+
+## Data type name
+
+The data type is specified as `"complex_float64"`.
+
+## Configuration
+
+None.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float64/schema.json
+++ b/data-types/complex_float64/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "complex_float64"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "complex_float64"
+    }
+  ]
+}

--- a/data-types/complex_float6_e2m3fn/README.md
+++ b/data-types/complex_float6_e2m3fn/README.md
@@ -1,0 +1,34 @@
+# complex_float6_e2m3fn data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float6_e2m3fn` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float6_e2m3fn"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float6_e2m3fn` data type. The `"endian"`
+parameter has no effect.
+
+### packbits
+
+Encoded as 2 consecutive (real component followed by imaginary component) 6-bit
+values, each encoded as specified by the `float6_e2m3fn` data type.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float6_e2m3fn/schema.json
+++ b/data-types/complex_float6_e2m3fn/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e8m0fnu"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e8m0fnu"
+    }
+  ]
+}

--- a/data-types/complex_float6_e3m2fn/README.md
+++ b/data-types/complex_float6_e3m2fn/README.md
@@ -1,0 +1,34 @@
+# complex_float6_e3m2fn data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float6_e3m2fn` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float6_e3m2fn"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float6_e3m2fn` data type. The `"endian"`
+parameter has no effect.
+
+### packbits
+
+Encoded as 2 consecutive (real component followed by imaginary component) 6-bit
+values, each encoded as specified by the `float6_e3m2fn` data type.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float6_e3m2fn/schema.json
+++ b/data-types/complex_float6_e3m2fn/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e8m0fnu"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e8m0fnu"
+    }
+  ]
+}

--- a/data-types/complex_float8_e3m4/README.md
+++ b/data-types/complex_float8_e3m4/README.md
@@ -1,0 +1,29 @@
+# complex_float8_e3m4 data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float8_e3m4` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float8_e3m4"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float8_e3m4` data type. The `"endian"`
+parameter has no effect.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float8_e3m4/schema.json
+++ b/data-types/complex_float8_e3m4/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e3m4"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e3m4"
+    }
+  ]
+}

--- a/data-types/complex_float8_e4m3/README.md
+++ b/data-types/complex_float8_e4m3/README.md
@@ -1,0 +1,29 @@
+# complex_float8_e4m3 data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float8_e4m3` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float8_e4m3"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float8_e4m3` data type. The `"endian"`
+parameter has no effect.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float8_e4m3/schema.json
+++ b/data-types/complex_float8_e4m3/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e4m3"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e4m3"
+    }
+  ]
+}

--- a/data-types/complex_float8_e4m3b11fnuz/README.md
+++ b/data-types/complex_float8_e4m3b11fnuz/README.md
@@ -1,0 +1,29 @@
+# complex_float8_e4m3b11fnuz data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float8_e4m3b11fnuz` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float8_e4m3b11fnuz"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float8_e4m3b11fnuz` data type. The `"endian"`
+parameter has no effect.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float8_e4m3b11fnuz/schema.json
+++ b/data-types/complex_float8_e4m3b11fnuz/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e4m3b11fnuz"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e4m3b11fnuz"
+    }
+  ]
+}

--- a/data-types/complex_float8_e4m3fnuz/README.md
+++ b/data-types/complex_float8_e4m3fnuz/README.md
@@ -1,0 +1,29 @@
+# complex_float8_e4m3fnuz data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float8_e4m3fnuz` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float8_e4m3fnuz"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float8_e4m3fnuz` data type. The `"endian"`
+parameter has no effect.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float8_e4m3fnuz/schema.json
+++ b/data-types/complex_float8_e4m3fnuz/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e4m3fnuz"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e4m3fnuz"
+    }
+  ]
+}

--- a/data-types/complex_float8_e5m2/README.md
+++ b/data-types/complex_float8_e5m2/README.md
@@ -1,0 +1,29 @@
+# complex_float8_e5m2 data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float8_e5m2` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float8_e5m2"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float8_e5m2` data type. The `"endian"`
+parameter has no effect.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float8_e5m2/schema.json
+++ b/data-types/complex_float8_e5m2/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e8m0fnu"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e8m0fnu"
+    }
+  ]
+}

--- a/data-types/complex_float8_e5m2fnuz/README.md
+++ b/data-types/complex_float8_e5m2fnuz/README.md
@@ -1,0 +1,29 @@
+# complex_float8_e5m2fnuz data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float8_e5m2fnuz` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float8_e5m2fnuz"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float8_e5m2fnuz` data type. The `"endian"`
+parameter has no effect.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float8_e5m2fnuz/schema.json
+++ b/data-types/complex_float8_e5m2fnuz/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e5m2fnuz"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e5m2fnuz"
+    }
+  ]
+}

--- a/data-types/complex_float8_e8m0fnu/README.md
+++ b/data-types/complex_float8_e8m0fnu/README.md
@@ -1,0 +1,29 @@
+# complex_float8_e8m0fnu data type
+
+Defines a complex number data type where the real and imaginary components are
+represented by the `float8_e8m0fnu` data type.
+
+## Data type name
+
+The data type is specified as `"complex_float8_e8m0fnu"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core complex number data data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as 2 consecutive (real component followed by imaginary component) 1-byte
+values, each encoded as specified by the `float8_e8m0fnu` data type. The `"endian"`
+parameter has no effect.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/complex_float8_e8m0fnu/schema.json
+++ b/data-types/complex_float8_e8m0fnu/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e8m0fnu"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e8m0fnu"
+    }
+  ]
+}

--- a/data-types/float4_e2m1fn/README.md
+++ b/data-types/float4_e2m1fn/README.md
@@ -1,0 +1,49 @@
+# float4_e2m1fn data type
+
+Defines a 4-bit floating point representation with:
+
+- 1 sign bit
+- 2 exponent bits, with bias of 1
+- 1 mantissa bit
+- Extended range: no infinity, no NaN.
+- Subnormal numbers when biased exponent is 0.
+
+## Data type name
+
+The data type is specified as `"float4_e2m1fn"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+- The constants `"Infinity"`, `"-Infinity"`, and `"NaN"` are not supported since
+  there is no corresponding representation.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bXXXXSEEM`. The `"endian"` parameter has no effect.
+The upper `XXXX` bits are ignored.
+
+### packbits
+
+Encoded as a 4-bit value `0bSEEM`.
+
+## See also
+
+- Specified as the E2M1 format by [OpenCompute
+  MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
+  `Float4E2M1FN`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float4_e2m1fn/schema.json
+++ b/data-types/float4_e2m1fn/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float4_e2m1fn"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float4_e2m1fn"
+    }
+  ]
+}

--- a/data-types/float6_e2m3fn/README.md
+++ b/data-types/float6_e2m3fn/README.md
@@ -1,0 +1,49 @@
+# float6_e2m3fn data type
+
+Defines a 6-bit floating point representation with:
+
+- 1 sign bit
+- 2 exponent bits, with bias of 1
+- 3 mantissa bits
+- Extended range: no infinity, no NaN.
+- Subnormal numbers when biased exponent is 0.
+
+## Data type name
+
+The data type is specified as `"float6_e2m3fn"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+- The constants `"Infinity"`, `"-Infinity"`, and `"NaN"` are not supported since
+  there is no corresponding representation.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bXXSEEMMM`. The `"endian"` parameter has no effect.
+The upper `XX` bits are ignored.
+
+### packbits
+
+Encoded as a 6-bit value `0bSEEMMM`.
+
+## See also
+
+- Specified as the E2M3 format by [OpenCompute
+  MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
+  `Float6E2M3FN`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float6_e2m3fn/schema.json
+++ b/data-types/float6_e2m3fn/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float6_e2m3fn"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float6_e2m3fn"
+    }
+  ]
+}

--- a/data-types/float6_e3m2fn/README.md
+++ b/data-types/float6_e3m2fn/README.md
@@ -1,0 +1,49 @@
+# float6_e3m2fn data type
+
+Defines a 6-bit floating point representation with:
+
+- 1 sign bit
+- 3 exponent bits, with bias of 3
+- 2 mantissa bits
+- Extended range: no infinity, no NaN.
+- Subnormal numbers when biased exponent is 0.
+
+## Data type name
+
+The data type is specified as `"float6_e3m2fn"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+- The constants `"Infinity"`, `"-Infinity"`, and `"NaN"` are not supported since
+  there is no corresponding representation.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bXXSEEEMM`. The `"endian"` parameter has no effect.
+The upper `XX` bits are ignored.
+
+### packbits
+
+Encoded as a 6-bit value `0bSEEEMM`.
+
+## See also
+
+- Specified as the E3M2 format by [OpenCompute
+  MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
+  `Float6E3M2FN`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float6_e3m2fn/schema.json
+++ b/data-types/float6_e3m2fn/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float6_e3m2fn"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float6_e3m2fn"
+    }
+  ]
+}

--- a/data-types/float8_e3m4/README.md
+++ b/data-types/float8_e3m4/README.md
@@ -1,0 +1,40 @@
+# float8_e3m4 data type
+
+Defines an 8-bit floating point representation with:
+
+- 1 sign bit
+- 3 exponent bits, with bias of 3
+- 4 mantissa bits
+- IEEE 754-compliant, with NaN and +/-inf.
+- Subnormal numbers when biased exponent is 0.
+
+## Data type name
+
+The data type is specified as `"float8_e3m4"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+The constant `"NaN"` corresponds to a representation of `"0x78"`.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bSEEEMMMM`.  The `"endian"` parameter has no effect.
+
+## See also
+
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `FloatE3M4`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float8_e3m4/schema.json
+++ b/data-types/float8_e3m4/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e3m4"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e3m4"
+    }
+  ]
+}

--- a/data-types/float8_e4m3/README.md
+++ b/data-types/float8_e4m3/README.md
@@ -1,0 +1,44 @@
+# float8_e4m3 data type
+
+Defines an 8-bit floating point representation with:
+
+- 1 sign bit
+- 4 exponent bits, with bias of 7
+- 3 mantissa bits
+- IEEE 754-compliant, with NaN and +/-inf.
+- Subnormal numbers when biased exponent is 0.
+
+## Data type name
+
+The data type is specified as `"float8_e4m3"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+The constant `"NaN"` corresponds to a representation of `"0x7c"`.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bSEEEEMMM`.  The `"endian"` parameter has no effect.
+
+## See also
+
+- Bit layout described by https://arxiv.org/abs/2209.05433
+- Specified as the E4M3 format by [OpenCompute
+  MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
+  `FloatE4M3`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float8_e4m3/schema.json
+++ b/data-types/float8_e4m3/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e4m3"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e4m3"
+    }
+  ]
+}

--- a/data-types/float8_e4m3b11fnuz/README.md
+++ b/data-types/float8_e4m3b11fnuz/README.md
@@ -1,0 +1,47 @@
+# float8_e4m3b11fnuz data type
+
+Defines an 8-bit floating point representation with:
+
+- 1 sign bit
+- 4 exponent bits, with bias of 11
+- 3 mantissa bits
+- Extended range: no infinity, NaN represented by `0b1000'0000`.
+- Subnormal numbers when biased exponent is 0.
+
+The suffix fnuz is consistent with LLVM/MLIR naming and is derived from the
+differences to IEEE floating point conventions. `F` is for "finite" (no
+infinities), `N` for with special NaN encoding, `UZ` for unsigned zero.
+
+## Data type name
+
+The data type is specified as `"float8_e4m3b11fnuz"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+- The constant `"NaN"` corresponds to a representation of `"0x80"`.
+- The constants `"Infinity"` and `"-Infinity"` are not supported since there is
+  no representation of infinity.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bSEEEEMMM`.  The `"endian"` parameter has no effect.
+
+## See also
+
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
+  `Float8E4M3B11FNUZ`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float8_e4m3b11fnuz/schema.json
+++ b/data-types/float8_e4m3b11fnuz/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e4m3b11fnuz"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e4m3b11fnuz"
+    }
+  ]
+}

--- a/data-types/float8_e4m3fnuz/README.md
+++ b/data-types/float8_e4m3fnuz/README.md
@@ -1,0 +1,48 @@
+# float8_e4m3fnuz data type
+
+Defines an 8-bit floating point representation with:
+
+- 1 sign bit
+- 4 exponent bits, with bias of 8
+- 3 mantissa bits
+- Extended range: no infinity, NaN represented by `0b1000'0000`.
+- Subnormal numbers when biased exponent is 0.
+
+The suffix fnuz is consistent with LLVM/MLIR naming and is derived from the
+differences to IEEE floating point conventions. `F` is for "finite" (no
+infinities), `N` for with special NaN encoding, `UZ` for unsigned zero.
+
+## Data type name
+
+The data type is specified as `"float8_e4m3fnuz"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+- The constant `"NaN"` corresponds to a representation of `"0x80"`.
+- The constants `"Infinity"` and `"-Infinity"` are not supported since there is
+  no representation of infinity.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bSEEEEMMM`.  The `"endian"` parameter has no effect.
+
+## See also
+
+- Bit layout described by https://arxiv.org/abs/2206.02915
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
+  `Float8E4M3FNUZ`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float8_e4m3fnuz/schema.json
+++ b/data-types/float8_e4m3fnuz/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e4m3fnuz"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e4m3fnuz"
+    }
+  ]
+}

--- a/data-types/float8_e5m2/README.md
+++ b/data-types/float8_e5m2/README.md
@@ -1,0 +1,44 @@
+# float8_e5m2 data type
+
+Defines an 8-bit floating point representation with:
+
+- 1 sign bit
+- 5 exponent bits, with bias of 15
+- 2 mantissa bits
+- IEEE 754-compliant, with NaN and +/-inf.
+- Subnormal numbers when biased exponent is 0.
+
+## Data type name
+
+The data type is specified as `"float8_e5m2"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+The constant `"NaN"` corresponds to a representation of `"0x7e"`.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bSEEEEEMM`.  The `"endian"` parameter has no effect.
+
+## See also
+
+- Bit layout described by https://arxiv.org/abs/2209.05433
+- Specified as the E5M2 format by [OpenCompute
+  MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
+  `Float8E5M2`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float8_e5m2/schema.json
+++ b/data-types/float8_e5m2/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e5m2"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e5m2"
+    }
+  ]
+}

--- a/data-types/float8_e5m2fnuz/README.md
+++ b/data-types/float8_e5m2fnuz/README.md
@@ -1,0 +1,47 @@
+# float8_e5m2fnuz data type
+
+Defines an 8-bit floating point representation with:
+
+- 1 sign bit
+- 5 exponent bits, with bias of 16
+- 3 mantissa bits
+- Extended range: no infinity, NaN represented by `0b1000'0000`.
+- Subnormal numbers when biased exponent is 0.
+
+The suffix fnuz is consistent with LLVM/MLIR naming and is derived from the
+differences to IEEE floating point conventions. `F` is for "finite" (no
+infinities), `N` for with special NaN encoding, `UZ` for unsigned zero.
+
+## Data type name
+
+The data type is specified as `"float8_e5m2fnuz"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+- The constant `"NaN"` corresponds to a representation of `"0x80"`.
+- The constants `"Infinity"` and `"-Infinity"` are not supported since there is
+  no representation of infinity.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bSEEEEEMM`.  The `"endian"` parameter has no effect.
+
+## See also
+
+- Bit layout described by https://arxiv.org/abs/2206.02915
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `FloatE4M3`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float8_e5m2fnuz/schema.json
+++ b/data-types/float8_e5m2fnuz/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e5m2fnuz"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e5m2fnuz"
+    }
+  ]
+}

--- a/data-types/float8_e8m0fnu/README.md
+++ b/data-types/float8_e8m0fnu/README.md
@@ -1,0 +1,48 @@
+# float8_e8m0fnu data type
+
+Defines an 8-bit floating point representation with:
+
+- No sign bit (unsigned).
+- 8 exponent bits, with bias of 127.
+- No mantissa bits
+- No zero, no infinity, NaN represented by `0b1111'1111`.
+- No subnormal numbers.
+
+The suffix fnu is consistent with LLVM/MLIR naming and is derived from the
+differences to IEEE floating point conventions. `F` is for "finite" (no
+infinities), `N` for with special NaN encoding, `U` for unsigned without zero.
+
+## Data type name
+
+The data type is specified as `"float8_e8m0fnu"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core IEEE 754 floating point
+numbers:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+- The constant `"NaN"` corresponds to a representation of `"0xFF"`.
+- The constants `"Infinity"` and `"-Infinity"` are not supported since there is
+  no representation of infinity.
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value `0bEEEEEEEE`.  The `"endian"` parameter has no effect.
+
+## See also
+
+- Defined as the *scale* format E8M0 by [OpenCompute
+  MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `Float8E8M0FN`.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/float8_e8m0fnu/schema.json
+++ b/data-types/float8_e8m0fnu/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "float8_e8m0fnu"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "float8_e8m0fnu"
+    }
+  ]
+}

--- a/data-types/int2/README.md
+++ b/data-types/int2/README.md
@@ -1,0 +1,37 @@
+# int2 data type
+
+Defines a signed integer in the range `[-2, 1]`.
+
+## Data type name
+
+The data type is specified as `"int2"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core integer data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value, `0bIIIIIIXX` where the upper `IIIIII` bits are
+ignored. The `"endian"` parameter has no effect. The upper `IIIIII` bits are
+arbitrary, but for better compressibility it is recommended to set them to a
+consistent value when writing.
+
+### packbits
+
+Encoded as a 2-bit value.
+
+## See also
+
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/int2/schema.json
+++ b/data-types/int2/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "int2"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "int2"
+    }
+  ]
+}

--- a/data-types/int4/README.md
+++ b/data-types/int4/README.md
@@ -1,0 +1,37 @@
+# int4 data type
+
+Defines a signed integer in the range `[-8, 7]`.
+
+## Data type name
+
+The data type is specified as `"int4"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core integer data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value, `0bIIIIXXXX` where the upper `IIII` bits are ignored.
+The `"endian"` parameter has no effect. The upper `IIII` bits are arbitrary, but
+for better compressibility it is recommended to set them to a consistent value
+when writing.
+
+### packbits
+
+Encoded as a 4-bit value.
+
+## See also
+
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/int4/schema.json
+++ b/data-types/int4/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "int4"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "int4"
+    }
+  ]
+}

--- a/data-types/uint2/README.md
+++ b/data-types/uint2/README.md
@@ -1,0 +1,37 @@
+# uint2 data type
+
+Defines an unsigned integer in the range `[0, 3]`.
+
+## Data type name
+
+The data type is specified as `"uint2"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core integer data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value, `0bIIIIIIXX` where the upper `IIIIII` bits are
+ignored. The `"endian"` parameter has no effect. The upper `IIIIII` bits are
+arbitrary, but for better compressibility it is recommended to set them to a
+consistent value when writing.
+
+### packbits
+
+Encoded as a 2-bit value.
+
+## See also
+
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/uint2/schema.json
+++ b/data-types/uint2/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "uint2"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "uint2"
+    }
+  ]
+}

--- a/data-types/uint4/README.md
+++ b/data-types/uint4/README.md
@@ -1,0 +1,37 @@
+# uint4 data type
+
+Defines an unsigned integer in the range `[0, 15]`.
+
+## Data type name
+
+The data type is specified as `"uint4"`.
+
+## Configuration
+
+None.
+
+## Fill value representation
+
+The fill value is specified in the same way as the core integer data types:
+https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#fill-value
+
+## Codec compatibility
+
+### bytes
+
+Encoded as a 1-byte value, `0bIIIIXXXX` where the upper `IIII` bits are ignored.
+The `"endian"` parameter has no effect. The upper `IIII` bits are arbitrary, but
+for better compressibility it is recommended to set them to a consistent value
+when writing.
+
+### packbits
+
+Encoded as a 4-bit value.
+
+## See also
+
+- Python implementation available at https://pypi.org/project/ml-dtypes/
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/uint4/schema.json
+++ b/data-types/uint4/schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "uint4"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    {
+      "const": "uint4"
+    }
+  ]
+}


### PR DESCRIPTION
I intend to also register all of the other data types listed here:

https://pypi.org/project/ml-dtypes/

8-bit floating point representations, parameterized by number of exponent and mantissa bits, as well as the bias (if any) and representability of infinity, NaN, and signed zero.

float8_e3m4
float8_e4m3
float8_e4m3b11fnuz
float8_e4m3fn
float8_e4m3fnuz
float8_e5m2
float8_e5m2fnuz
float8_e8m0fnu

Microscaling (MX) sub-byte floating point representations:

float4_e2m1fn
float6_e2m3fn
float6_e3m2fn

Narrow integer encodings:

int2
int4
uint2
uint4

Potentially I'll add the others to this PR, but I wanted to make sure the bfloat16 README was in order first.

There are a few questions I have:

- Should they all be specified as independent documents, or should some be combined to a single document somehow?
- Should a trivial schema just listing the data type name be provided?
- I have a link to the main spec, which unfortunately includes "v3.0" which presumably will become stale at some point.
- Data types interact with other things in the spec in a few ways:
  - Fill values
  - Codecs

Currently, for the core data types, we specify the fill value representation under the `fill_value` section, separately from where the data types themselves are defined.

We have to specify how the data type is handled by each codec that supports it.  In the case of bfloat16 it is only the `bytes` codec.  The `bytes` codec description itself specifies how it handles all of the core data types, but presumably we would instead specify that as part of the extension data type specification.

In the case of bfloat16, the `bytes` encoding is so obvious that it hardly requires any explanation at all.  For the other data types listed above that are less than 1 byte, however, we have to say that they will be padded to 1 byte with the high bits ignored.  Additionally, I may want to register a `pack_bits` codec in the future that would support `bool` as well as these other data types that are less than 1 byte.

If I am the maintainer of all of the relevant extensions then there is no issue since I can modify them to reference each other as needed, but if I were not, it is less clear how we would deal with this.