### PR TITLE
feature(data-types): add data-types from https://github.com/zarr-developers/zarr-python/pull/2874

### DIFF
--- a/data-types/datetime64/README.md
+++ b/data-types/datetime64/README.md
@@ -1,0 +1,33 @@
+# Datetime64 data type
+
+Defines a data type for a datetime object based on a 64-bit integer.
+
+## Permitted fill values
+
+The value of the `fill_value` metadata key must be a signed 64-bit integer.
+
+## Example
+
+For example, the array metadata below specifies that the array uses the datetime64 data type:
+
+```json
+{
+    "data_type": "datetime64",
+    "fill_value": -9223372036854775808,
+    "configuration": {
+      "unit": "s"
+    },
+}
+```
+
+## Notes
+
+Valid values for the `unit` configuration option include: `["Y", "M", "W", "D", "h", "m", "s", "ms", "us", "μs", "ns", "ps", "fs", "as"]`
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* [zarr-python core development team](https://github.com/orgs/zarr-developers/teams/python-core-devs)

--- a/data-types/datetime64/schema.json
+++ b/data-types/datetime64/schema.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": [
+      {
+        "type": "object",
+        "properties": {
+          "name": {
+            "const": "datetime64"
+          },
+          "configuration": {
+            "type": "object",
+            "properties": {
+              "unit": {
+                "type": "string"
+              }
+            },
+            "required": ["unit"],
+            "additionalProperties": false
+          }
+        },
+        "required": ["name", "configuration"],
+        "additionalProperties": false
+      },
+      { "const": "datetime64" }
+    ]
+  }

--- a/data-types/fixed-length-ascii/README.md
+++ b/data-types/fixed-length-ascii/README.md
@@ -1,0 +1,33 @@
+# Fixed-length ASCII data type
+
+Defines a data type for fixed-length ASCII strings.
+
+## Permitted fill values
+
+The value of the `fill_value` metadata key must be a string.
+
+## Example
+
+For example, the array metadata below specifies that the array contains fixed-length ASCII strings:
+
+```json
+{
+    "data_type": "fixed-length-ascii",
+    "fill_value": "",
+    "configuration": {
+      "length_bits": 24
+    },
+}
+```
+
+## Notes
+
+TBD
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* [zarr-python core development team](https://github.com/orgs/zarr-developers/teams/python-core-devs)

--- a/data-types/fixed-length-ascii/schema.json
+++ b/data-types/fixed-length-ascii/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "fixed-length-ascii"
+        },
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "length_bits": {
+              "type": "integer"
+            }
+          },
+          "required": ["length_bits"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["name", "configuration"],
+      "additionalProperties": false
+    },
+    { "const": "fixed-length-ascii" }
+  ]
+}

--- a/data-types/fixed-length-bytes/README.md
+++ b/data-types/fixed-length-bytes/README.md
@@ -1,0 +1,33 @@
+# Fixed-length bytes data type
+
+Defines a data type for fixed-length byte strings.
+
+## Permitted fill values
+
+The value of the `fill_value` metadata key must be a string.
+
+## Example
+
+For example, the array metadata below specifies that the array contains fixed-length byte strings:
+
+```json
+{
+    "data_type": "fixed-length-bytes",
+    "fill_value": "",
+    "configuration": {
+      "length_bits": 24
+    },
+}
+```
+
+## Notes
+
+TBD
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* [zarr-python core development team](https://github.com/orgs/zarr-developers/teams/python-core-devs)

--- a/data-types/fixed-length-bytes/schema.json
+++ b/data-types/fixed-length-bytes/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "fixed-length-bytes"
+        },
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "length_bits": {
+              "type": "integer"
+            }
+          },
+          "required": ["length_bits"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["name", "configuration"],
+      "additionalProperties": false
+    },
+    { "const": "fixed-length-bytes" }
+  ]
+}

--- a/data-types/fixed-length-ucs4/README.md
+++ b/data-types/fixed-length-ucs4/README.md
@@ -1,0 +1,33 @@
+# Fixed-length Unicode string data type
+
+Defines a data type for fixed-length Unicode strings.
+
+## Permitted fill values
+
+The value of the `fill_value` metadata key must be a string.
+
+## Example
+
+For example, the array metadata below specifies that the array contains fixed-length unicode strings:
+
+```json
+{
+    "data_type": "fixed-length-ucs4",
+    "fill_value": "",
+    "configuration": {
+      "length_bits": 24
+    },
+}
+```
+
+## Notes
+
+TBD
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* [zarr-python core development team](https://github.com/orgs/zarr-developers/teams/python-core-devs)

--- a/data-types/fixed-length-ucs4/schema.json
+++ b/data-types/fixed-length-ucs4/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "fixed-length-ucs4"
+        },
+        "configuration": {
+          "type": "object",
+          "properties": {
+            "length_bits": {
+              "type": "integer"
+            }
+          },
+          "required": ["length_bits"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["name", "configuration"],
+      "additionalProperties": false
+    },
+    { "const": "fixed-length-ucs4" }
+  ]
+}


### PR DESCRIPTION
This PR adds the definition of the 4 new data types from https://github.com/zarr-developers/zarr-python/pull/2874. They include:

- datetime64
- fixed-length-ascii
- fixed-length-bytes
- fixed-length-ucs4

Closes #4 

xref: https://github.com/zarr-developers/zarr-python/pull/2874