### PR TITLE
Reserve characters in names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,29 @@ The review will be done largely based on avoiding confusing extension names and 
 Extension maintainers are responsible for their extensions.
 Updates to the extensions will also be reviewed by the steering council.
 
+## Name conventions
+
+Registered extensions SHOULD use alphanumeric characters or underscore, `_`.
+
+Registered extensions MUST NOT use reserved characters. The following characters are reserved.
+
+```
+reserved = uri-gen-delims / uri-sub-delims / namespace-delims
+
+uri-gen-delims = ":" / "/" / "?" / "#" / "[" / "]" / "@"
+
+uri-sub-delims = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+
+namespace-delims = "." / "-" / "~"
+```
+
+The reserved characters are a superset of reserved in [RFC3986].
+
+[RFC3986] Berners-Lee, T., Fielding, R., and L. Masinter, "Uniform Resource Identifier (URI): Generic Syntax", STD 66, RFC 3986, DOI 10.17487/RFC3986, January 2005, 
+https://tools.ietf.org/html/rfc3986.
+
+[RFC3986]:
+https://tools.ietf.org/html/rfc3986
 
 ## Document conventions
 
@@ -49,7 +72,8 @@ introduced with the words "for example".
    Requirement Levels. March 1997. Best Current Practice. URL:
    https://tools.ietf.org/html/rfc2119
 
-[RFC2119]: https://tools.ietf.org/html/rfc2119
+[RFC2119]:
+https://tools.ietf.org/html/rfc2119
 
 ## License
 


### PR DESCRIPTION
This PR reserves characters in registered names.

The intention is to reserve characters to allow for namespace or a specific URI schemes in the future.

The reservations include all URI reserved characters as in RFC 3986.

They additionally include ".", "-", and "~". Underscores are allowed since `sharding_index` is already used.

xref: https://github.com/zarr-developers/zarr-specs/pull/330#issuecomment-2813003630

Capitalization should be considered in a future pull request. I recommend reserving all capital letters.