### PR TITLE
add `zfp` codec

### DIFF
--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -49,10 +49,10 @@ More examples can be viewed in the [examples](./examples/) subdirectory.
 ## Supported Chunk Shapes
 
 `zfp` natively only supports 1, 2, 3 and 4 dimensional arrays.
-However, implementations may support encoding of chunks with more than 4 dimensions provided that at most 4 dimensions have a chunk size greater than 1.
-- If the number of dimensions with chunk size > 1 is within the range [1, 4], those are the `zfp` dimensions.
-- If there are more than 4 such dimensions, it is an error.
-- If there are zero such dimensions, i.e. the chunk contains just a single element, treat it as a 1-d array of 1 element.
+Implementations can support higher dimensional arrays by collapsing dimensions of size 1.
+For example, a chunk of shape [4, 1, 3, 1, 2, 1] would have a zfp shape of [4, 3, 2].
+If the zfp shape has more than 4 dimensions after collapsing, it is an error.
+Dimensions of size 1 MUST NOT be collapsed for 1 to 4 dimensional arrays.
 
 These rules apply to the inner chunk shape if this codec is used as the array-to-bytes codec within the `sharding_indexed` codec.
 

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -49,7 +49,8 @@ More examples can be viewed in the [examples](./examples/) subdirectory.
 ## Supported Chunk Shapes
 
 `zfp` natively only supports 1, 2, 3 and 4 dimensional arrays.
-Implementations can support higher dimensional arrays by collapsing dimensions of size 1.
+
+This codec allows for encoding of higher dimensional arrays by collapsing dimensions of size 1.
 For example, a chunk of shape [4, 1, 3, 1, 2, 1] would have a zfp shape of [4, 3, 2].
 If the zfp shape has more than 4 dimensions after collapsing, it is an error.
 Dimensions of size 1 MUST NOT be collapsed for 1 to 4 dimensional arrays.

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -1,0 +1,88 @@
+# ZFP codec
+
+Defines a `array -> bytes` codec that compresses chunks using the [zfp](https://github.com/LLNL/zfp) algorithm.
+
+## Codec name
+
+The value of the `name` member in the codec object MUST be `zarrs.zfp`.
+
+## Configuration parameters
+
+The configuration of this codec matches the compression modes defined at <https://zfp.readthedocs.io/en/latest/modes.html#expert-mode>.
+Refer to that page for usage information.
+
+The codec has one parameter which is always required:
+- `mode` (string).
+
+The other required parameters are dependent on the `mode`:
+- `"mode": "reversible"`
+- `"mode": "expert"`
+    - `minbits` (unsigned integer)
+    - `maxbits` (unsigned integer)
+    - `maxprec` (unsigned integer)
+    - `minexp` (signed integer)
+- `"mode": "fixed_accuracy"`
+    - `tolerance` (number)
+- `"mode": "fixed_rate"`
+    - `rate` (number)
+- `"fixed_precision"`
+    - `precision` (unsigned integer)
+
+## Example
+
+For example, the array metadata below specifies that the array contains zfp compressed chunks using `fixed_accuracy` mode with a tolerance of 0.05:
+
+```json
+{
+    "codecs": [{
+        "name": "zarrs.zfp",
+        "configuration": {
+            "mode": "fixed_accuracy",
+            "tolerance": 0.05
+        }
+    }],
+}
+```
+
+More examples can be viewed in the [examples](./examples/) subdirectory.
+
+## Supported Data Types
+
+- `int32`, `uint32`, `int64`, `uint64`, `float32`, `float64`
+- `int8`, `uint8`, `int16`, `uint16` (through internal promotion 32-bit)
+
+Implementations are permitted to support additional data types that could be interpreted as the above data types (e.g. `datetime64` -> `uint64`).
+
+## Format and algorithm
+
+This format is tightly coupled to the [`zfp` C library](https://zfp.readthedocs.io/en/latest/).
+
+### Compression
+
+1. 8 and 16-bit integer data types must be promoted to 32-bit in accordance with the appropriate `zfp_promote_*` method.
+2. Data is compressed with `zfp_compress`.
+
+### Decompression
+
+1. Data is decompressed with `zfp_decompress`.
+2. 8 and 16-bit integer data types should be demoted in accordance with the appropriate `zfp_demote_*` method.
+
+## Differences from `numcodecs.zfpy`
+
+- `mode` is a string rather than an integer.
+- `mode` supports `reversible` and `expert` mode.
+- 8 and 16-bit integer data types are supported.
+- a header is not written with [`zfp_write_header`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#c.zfp_write_header).
+  - This header is redundant given the information in the codec configuration.
+
+> [!NOTE]
+> An earlier version of the `zfp` codec in `zarrs` Rust crate included an optional [`write_header` parameter](https://docs.rs/zarrs_metadata/0.3.7/zarrs_metadata/v3/array/codec/zfp/struct.ZfpCodecConfigurationV1.html) in the codec configuration.
+> This has since been removed in favor of better separating `zfp` and `zfpy`.
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* [Lachlan Deakin](https://github.com/LDeakin)

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -4,7 +4,7 @@ Defines a `array -> bytes` codec that compresses chunks using the [zfp](https://
 
 ## Codec name
 
-The value of the `name` member in the codec object MUST be `zarrs`.
+The value of the `name` member in the codec object MUST be `zfp`.
 
 ## Configuration parameters
 
@@ -35,7 +35,7 @@ For example, the array metadata below specifies that the array contains zfp comp
 ```json
 {
     "codecs": [{
-        "name": "zarrs",
+        "name": "zfp",
         "configuration": {
             "mode": "fixed_accuracy",
             "tolerance": 0.05

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -49,9 +49,10 @@ More examples can be viewed in the [examples](./examples/) subdirectory.
 ## Supported Data Types
 
 - `int32`, `uint32`, `int64`, `uint64`, `float32`, `float64`
-- `int8`, `uint8`, `int16`, `uint16` (through internal promotion 32-bit)
 
-Implementations are permitted to support additional data types that could be interpreted as the above data types (e.g. `datetime64` -> `int64`).
+Implementations may support lower-precision data types (e.g. `float16`, `bfloat16`, `int4`, etc.) through promotion / casting to the above data types.
+
+Implementations may support additional data types that could be interpreted or promoted to the above data types (e.g. `datetime64` -> `int64`).
 
 ## Format and algorithm
 
@@ -59,19 +60,27 @@ This format is tightly coupled to the [`zfp` C library](https://zfp.readthedocs.
 
 ### Compression
 
-1. 8 and 16-bit integer data types must be promoted to 32-bit in accordance with the appropriate `zfp_promote_*` method.
+1. Lower-precision data types must be promoted to 32-bit
+  - Floating point data types (e.g. `float16`, `bfloat16`, etc.) can be supported by casting to `float32` in the normal way.
+  - Integer data types must be promoted to `int32` in accordance with the `zfp_promote_*` functions:
+    - `int` with `N` bits: `int32_value = (int32_t)intN_value << (31 - N)`
+    - `uint` with `N` bits: `int32_value = ((int32_t)uintN_value - (1<<(N-1))) << (31 - N)`
 2. Data is compressed with `zfp_compress`.
 
 ### Decompression
 
 1. Data is decompressed with `zfp_decompress`.
-2. 8 and 16-bit integer data types should be demoted in accordance with the appropriate `zfp_demote_*` method.
+2. Lower-precision data types are restored through demotion:
+  - Floating point data types (e.g. `float16`, `bfloat16`, etc.) can be supported by casting from `float32` in the normal way.
+  - Integer data types must be be demoted from `int32` in accordance with the appropriate `zfp_demote_*` functions:
+    - `int` with `N` bits: `intN_value = (intN_t)clamp(int32_value >> (31 - N), 1<<(N-1), (1<<(N-1)) - 1)`
+    - `uint` with `N` bits: `uintN_value = (uintN_t)clamp((int32_value >> (31 - N)) + (1<<(N-1)), 0, (1<<N) - 1)`
 
 ## Differences from `numcodecs.zfpy`
 
 - `mode` is a string rather than an integer.
 - `mode` supports `reversible` and `expert` mode.
-- 8 and 16-bit integer data types are supported.
+- Lower-precision integer and floating point data types are supported.
 - a header is not written with [`zfp_write_header`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#c.zfp_write_header).
   - This header is redundant given the information in the codec configuration.
 

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -46,6 +46,16 @@ For example, the array metadata below specifies that the array contains zfp comp
 
 More examples can be viewed in the [examples](./examples/) subdirectory.
 
+## Supported Chunk Shapes
+
+`zfp` natively only supports 1, 2, 3 and 4 dimensional arrays.
+However, this codec permits encoding of chunks with more than 4 dimensions provided that at most 4 dimensions have a chunk size greater than 1.
+- If the number of dimensions with chunk size > 1 is within the range [1, 4], those are the `zfp` dimensions.
+- If there are more than 4 such dimensions, it is an error.
+- If there are zero such dimensions, i.e. the chunk contains just a single element, treat it as a 1-d array of 1 element.
+
+These rules apply to the inner chunk shape if this codec is used as the array-to-bytes codec within the `sharding_indexed` codec.
+
 ## Supported Data Types
 
 - `int32`, `uint32`, `int64`, `uint64`, `float32`, `float64`
@@ -81,6 +91,7 @@ This format is tightly coupled to the [`zfp` C library](https://zfp.readthedocs.
 - `mode` is a string rather than an integer.
 - `mode` supports `reversible` and `expert` mode.
 - Lower-precision integer and floating point data types are supported.
+- Higher dimensional arrays are supported (provided that at most 4 dimensions have size greater than 1)
 - a header is not written with [`zfp_write_header`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#c.zfp_write_header).
   - This header is redundant given the information in the codec configuration.
 

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -97,7 +97,7 @@ This format is tightly coupled to the [`zfp` C library](https://zfp.readthedocs.
   - This header is redundant given the information in the codec configuration.
 
 > [!NOTE]
-> An earlier version of the `zfp` codec in `zarrs` Rust crate included an optional [`write_header` parameter](https://docs.rs/zarrs_metadata/0.3.7/zarrs_metadata/v3/array/codec/zfp/struct.ZfpCodecConfigurationV1.html) in the codec configuration.
+> An earlier version of the `zfp` codec in the `zarrs` Rust crate included an optional [`write_header` parameter](https://docs.rs/zarrs_metadata/0.3.7/zarrs_metadata/v3/array/codec/zfp/struct.ZfpCodecConfigurationV1.html) in the codec configuration.
 > This has since been removed in favor of better separating `zfp` and `zfpy`.
 
 ## Change log

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -4,7 +4,7 @@ Defines a `array -> bytes` codec that compresses chunks using the [zfp](https://
 
 ## Codec name
 
-The value of the `name` member in the codec object MUST be `zarrs.zfp`.
+The value of the `name` member in the codec object MUST be `zarrs`.
 
 ## Configuration parameters
 
@@ -35,7 +35,7 @@ For example, the array metadata below specifies that the array contains zfp comp
 ```json
 {
     "codecs": [{
-        "name": "zarrs.zfp",
+        "name": "zarrs",
         "configuration": {
             "mode": "fixed_accuracy",
             "tolerance": 0.05

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -49,7 +49,7 @@ More examples can be viewed in the [examples](./examples/) subdirectory.
 ## Supported Chunk Shapes
 
 `zfp` natively only supports 1, 2, 3 and 4 dimensional arrays.
-However, this codec permits encoding of chunks with more than 4 dimensions provided that at most 4 dimensions have a chunk size greater than 1.
+However, implementations may support encoding of chunks with more than 4 dimensions provided that at most 4 dimensions have a chunk size greater than 1.
 - If the number of dimensions with chunk size > 1 is within the range [1, 4], those are the `zfp` dimensions.
 - If there are more than 4 such dimensions, it is an error.
 - If there are zero such dimensions, i.e. the chunk contains just a single element, treat it as a 1-d array of 1 element.

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -51,7 +51,7 @@ More examples can be viewed in the [examples](./examples/) subdirectory.
 - `int32`, `uint32`, `int64`, `uint64`, `float32`, `float64`
 - `int8`, `uint8`, `int16`, `uint16` (through internal promotion 32-bit)
 
-Implementations are permitted to support additional data types that could be interpreted as the above data types (e.g. `datetime64` -> `uint64`).
+Implementations are permitted to support additional data types that could be interpreted as the above data types (e.g. `datetime64` -> `int64`).
 
 ## Format and algorithm
 

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -58,7 +58,7 @@ Chunk shapes are mapped to `zfp` field sizes according to the [`zfp_field_Nd`](h
 The chunk of a zero-dimensional Zarr array is interpreted as a 1D `zfp` field with `nx = 1`.
 
 Chunks with more than four dimensions are not supported directly by this codec.
-However, higher-dimensional arrays could be supported by collapsing singleton dimensions (dimensions of size 1) using a [`np.squeeze`](https://numpy.org/doc/stable/reference/generated/numpy.squeeze.html) inspired array-to-array codec, provided the resulting dimensionality is four or fewer.
+However, higher-dimensional arrays could be supported by preceeding this codec with a [`np.squeeze`](https://numpy.org/doc/stable/reference/generated/numpy.squeeze.html) inspired array-to-array codec that collapses singleton dimensions (dimensions of size 1), provided the resulting dimensionality is four or fewer.
 For example, a chunk with shape `[4, 1, 3, 1, 2, 1]` would be squeezed to a `zfp` field size of `[nz, ny, nx] = [4, 3, 2]`.
 
 These rules apply to the inner chunk shape if this codec is used as the array-to-bytes codec within the `sharding_indexed` codec.

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -49,8 +49,7 @@ More examples can be viewed in the [examples](./examples/) subdirectory.
 ## Supported Chunk Shapes
 
 `zfp` natively only supports 1, 2, 3 and 4 dimensional arrays.
-
-Chunks with 4 or fewer dimensions are mapped to `zfp` field sizes as follows (in accordance with the [`zfp_field_Nd`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#array-metadata) functions):
+Chunk shapes are mapped to `zfp` field sizes according to the [`zfp_field_Nd`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#array-metadata) APIs as follows:
  - 1D: `[nx]`
  - 2D: `[ny, nx]`
  - 3D: `[nz, ny, nx]`
@@ -58,10 +57,9 @@ Chunks with 4 or fewer dimensions are mapped to `zfp` field sizes as follows (in
 
 The chunk of a zero-dimensional Zarr array is interpreted as a 1D `zfp` field with `nx = 1`.
 
-Higher-dimensional chunks are supported by collapsing dimensions of size 1.
-For example, a chunk of shape `[4, 1, 3, 1, 2, 1]` would have a `zfp` field size of `[nz, ny, nx] = [4, 3, 2]`.
-If a chunk shape has more than 4 dimensions after collapsing, it is an error.
-Dimensions of size 1 MUST NOT be collapsed for 1 to 4 dimensional chunks.
+Chunks with more than four dimensions are not supported directly by this codec.
+However, higher-dimensional arrays could be supported by collapsing singleton dimensions (dimensions of size 1) using a [`np.squeeze`](https://numpy.org/doc/stable/reference/generated/numpy.squeeze.html) inspired array-to-array codec, provided the resulting dimensionality is four or fewer.
+For example, a chunk with shape `[4, 1, 3, 1, 2, 1]` would be squeezed to a `zfp` field size of `[nz, ny, nx] = [4, 3, 2]`.
 
 These rules apply to the inner chunk shape if this codec is used as the array-to-bytes codec within the `sharding_indexed` codec.
 
@@ -101,7 +99,6 @@ This format is tightly coupled to the [`zfp` C library](https://zfp.readthedocs.
 - `mode` is a string rather than an integer.
 - `mode` supports `reversible` and `expert` mode.
 - Lower-precision integer and floating point data types are supported.
-- Higher-dimensional arrays are supported (provided that at most 4 dimensions have size greater than 1)
 - a header is not written with [`zfp_write_header`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#c.zfp_write_header).
   - This header is redundant given the information in the codec configuration.
 

--- a/codecs/zarrs.zfp/README.md
+++ b/codecs/zarrs.zfp/README.md
@@ -30,7 +30,7 @@ The other required parameters are dependent on the `mode`:
 
 ## Example
 
-For example, the array metadata below specifies that the array contains zfp compressed chunks using `fixed_accuracy` mode with a tolerance of 0.05:
+For example, the array metadata below specifies that the array contains `zfp` compressed chunks using `fixed_accuracy` mode with a tolerance of 0.05:
 
 ```json
 {
@@ -50,10 +50,18 @@ More examples can be viewed in the [examples](./examples/) subdirectory.
 
 `zfp` natively only supports 1, 2, 3 and 4 dimensional arrays.
 
-This codec allows for encoding of higher dimensional arrays by collapsing dimensions of size 1.
-For example, a chunk of shape [4, 1, 3, 1, 2, 1] would have a zfp shape of [4, 3, 2].
-If the zfp shape has more than 4 dimensions after collapsing, it is an error.
-Dimensions of size 1 MUST NOT be collapsed for 1 to 4 dimensional arrays.
+Chunks with 4 or fewer dimensions are mapped to `zfp` field sizes as follows (in accordance with the [`zfp_field_Nd`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#array-metadata) functions):
+ - 1D: `[nx]`
+ - 2D: `[ny, nx]`
+ - 3D: `[nz, ny, nx]`
+ - 4D: `[nw, nz, ny, nx]`
+
+The chunk of a zero-dimensional Zarr array is interpreted as a 1D `zfp` field with `nx = 1`.
+
+Higher-dimensional chunks are supported by collapsing dimensions of size 1.
+For example, a chunk of shape `[4, 1, 3, 1, 2, 1]` would have a `zfp` field size of `[nz, ny, nx] = [4, 3, 2]`.
+If a chunk shape has more than 4 dimensions after collapsing, it is an error.
+Dimensions of size 1 MUST NOT be collapsed for 1 to 4 dimensional chunks.
 
 These rules apply to the inner chunk shape if this codec is used as the array-to-bytes codec within the `sharding_indexed` codec.
 
@@ -71,33 +79,34 @@ This format is tightly coupled to the [`zfp` C library](https://zfp.readthedocs.
 
 ### Compression
 
-1. Lower-precision data types must be promoted to 32-bit
-  - Floating point data types (e.g. `float16`, `bfloat16`, etc.) can be supported by casting to `float32` in the normal way.
-  - Integer data types must be promoted to `int32` in accordance with the `zfp_promote_*` functions:
-    - `int` with `N` bits: `int32_value = (int32_t)intN_value << (31 - N)`
-    - `uint` with `N` bits: `int32_value = ((int32_t)uintN_value - (1<<(N-1))) << (31 - N)`
-2. Data is compressed with `zfp_compress`.
+1. Lower-precision data types must first be promoted to 32-bit
+   - Floating point data types (e.g. `float16`, `bfloat16`, etc.) can be supported by casting to `float32` in the normal way.
+   - Integer data types must be promoted to `int32` in accordance with the [`zfp_promote_*`](https://zfp.readthedocs.io/en/release0.5.5/low-level-api.html#utility-functions) functions:
+     - `int` with `N` bits: `int32_value = (int32_t)intN_value << (31 - N)`
+     - `uint` with `N` bits: `int32_value = ((int32_t)uintN_value - (1<<(N-1))) << (31 - N)`
+2. The uncompressed data is represented as a contiguous array in a [`zfp_field`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#c.zfp_field) and compressed with `zfp_compress`:
+   - The field sizes are set in accordance with the rules described in [Supported Chunk Shapes](#supported-chunk-shapes).
 
 ### Decompression
 
-1. Data is decompressed with `zfp_decompress`.
+1. The data is decompressed into a contiguous array with `zfp_decompress`.
 2. Lower-precision data types are restored through demotion:
-  - Floating point data types (e.g. `float16`, `bfloat16`, etc.) can be supported by casting from `float32` in the normal way.
-  - Integer data types must be be demoted from `int32` in accordance with the appropriate `zfp_demote_*` functions:
-    - `int` with `N` bits: `intN_value = (intN_t)clamp(int32_value >> (31 - N), 1<<(N-1), (1<<(N-1)) - 1)`
-    - `uint` with `N` bits: `uintN_value = (uintN_t)clamp((int32_value >> (31 - N)) + (1<<(N-1)), 0, (1<<N) - 1)`
+   - Floating point data types (e.g. `float16`, `bfloat16`, etc.) can be supported by casting from `float32` in the normal way.
+   - Integer data types must be be demoted from `int32` in accordance with the appropriate [`zfp_demote_*`](https://zfp.readthedocs.io/en/release0.5.5/low-level-api.html#utility-functions) functions:
+     - `int` with `N` bits: `intN_value = (intN_t)clamp(int32_value >> (31 - N), 1<<(N-1), (1<<(N-1)) - 1)`
+     - `uint` with `N` bits: `uintN_value = (uintN_t)clamp((int32_value >> (31 - N)) + (1<<(N-1)), 0, (1<<N) - 1)`
 
 ## Differences from `numcodecs.zfpy`
 
 - `mode` is a string rather than an integer.
 - `mode` supports `reversible` and `expert` mode.
 - Lower-precision integer and floating point data types are supported.
-- Higher dimensional arrays are supported (provided that at most 4 dimensions have size greater than 1)
+- Higher-dimensional arrays are supported (provided that at most 4 dimensions have size greater than 1)
 - a header is not written with [`zfp_write_header`](https://zfp.readthedocs.io/en/release0.5.5/high-level-api.html#c.zfp_write_header).
   - This header is redundant given the information in the codec configuration.
 
 > [!NOTE]
-> An earlier version of the `zfp` codec in the `zarrs` Rust crate included an optional [`write_header` parameter](https://docs.rs/zarrs_metadata/0.3.7/zarrs_metadata/v3/array/codec/zfp/struct.ZfpCodecConfigurationV1.html) in the codec configuration.
+> An earlier version of the `zfp` codec in the [`zarrs`](https://github.com/LDeakin/zarrs) Rust crate included an optional [`write_header` parameter](https://docs.rs/zarrs_metadata/0.3.7/zarrs_metadata/v3/array/codec/zfp/struct.ZfpCodecConfigurationV1.html) in the codec configuration.
 > This has since been removed in favor of better separating `zfp` and `zfpy`.
 
 ## Change log

--- a/codecs/zarrs.zfp/examples/expert.json
+++ b/codecs/zarrs.zfp/examples/expert.json
@@ -1,0 +1,10 @@
+{
+  "name": "zarrs.zfp",
+  "configuration": {
+    "mode": "expert",
+    "minbits": 1,
+    "maxbits": 13,
+    "maxprec": 19,
+    "minexp": -2
+  }
+}

--- a/codecs/zarrs.zfp/examples/expert.json
+++ b/codecs/zarrs.zfp/examples/expert.json
@@ -1,5 +1,5 @@
 {
-  "name": "zarrs.zfp",
+  "name": "zfp",
   "configuration": {
     "mode": "expert",
     "minbits": 1,

--- a/codecs/zarrs.zfp/examples/fixed_accuracy.json
+++ b/codecs/zarrs.zfp/examples/fixed_accuracy.json
@@ -1,5 +1,5 @@
 {
-  "name": "zarrs.zfp",
+  "name": "zfp",
   "configuration": {
     "mode": "fixed_accuracy",
     "tolerance": 0.05

--- a/codecs/zarrs.zfp/examples/fixed_accuracy.json
+++ b/codecs/zarrs.zfp/examples/fixed_accuracy.json
@@ -1,0 +1,7 @@
+{
+  "name": "zarrs.zfp",
+  "configuration": {
+    "mode": "fixed_accuracy",
+    "tolerance": 0.05
+  }
+}

--- a/codecs/zarrs.zfp/examples/fixed_precision.json
+++ b/codecs/zarrs.zfp/examples/fixed_precision.json
@@ -1,5 +1,5 @@
 {
-  "name": "zarrs.zfp",
+  "name": "zfp",
   "configuration": {
     "mode": "fixed_precision",
     "precision": 19

--- a/codecs/zarrs.zfp/examples/fixed_precision.json
+++ b/codecs/zarrs.zfp/examples/fixed_precision.json
@@ -1,0 +1,7 @@
+{
+  "name": "zarrs.zfp",
+  "configuration": {
+    "mode": "fixed_precision",
+    "precision": 19
+  }
+}

--- a/codecs/zarrs.zfp/examples/fixed_rate.json
+++ b/codecs/zarrs.zfp/examples/fixed_rate.json
@@ -1,5 +1,5 @@
 {
-  "name": "zarrs.zfp",
+  "name": "zfp",
   "configuration": {
     "mode": "fixed_rate",
     "rate": 10.5

--- a/codecs/zarrs.zfp/examples/fixed_rate.json
+++ b/codecs/zarrs.zfp/examples/fixed_rate.json
@@ -1,0 +1,7 @@
+{
+  "name": "zarrs.zfp",
+  "configuration": {
+    "mode": "fixed_rate",
+    "rate": 10.5
+  }
+}

--- a/codecs/zarrs.zfp/examples/reversible.json
+++ b/codecs/zarrs.zfp/examples/reversible.json
@@ -1,0 +1,6 @@
+{
+  "name": "zarrs.zfp",
+  "configuration": {
+    "mode": "reversible"
+  }
+}

--- a/codecs/zarrs.zfp/examples/reversible.json
+++ b/codecs/zarrs.zfp/examples/reversible.json
@@ -1,5 +1,5 @@
 {
-  "name": "zarrs.zfp",
+  "name": "zfp",
   "configuration": {
     "mode": "reversible"
   }

--- a/codecs/zarrs.zfp/schema.json
+++ b/codecs/zarrs.zfp/schema.json
@@ -16,6 +16,7 @@
                   "const": "reversible"
                 }
               },
+              "required": ["mode"],
               "additionalProperties": false
             },
             {
@@ -40,6 +41,7 @@
                   "type": "integer"
                 }
               },
+              "required": ["mode", "minbits", "maxbits", "maxprec", "minexp"],
               "additionalProperties": false
             },
             {
@@ -52,6 +54,7 @@
                   "type": "number"
                 }
               },
+              "required": ["mode", "tolerance"],
               "additionalProperties": false
             },
             {
@@ -64,6 +67,7 @@
                   "type": "number"
                 }
               },
+              "required": ["mode", "rate"],
               "additionalProperties": false
             },
             {
@@ -77,6 +81,7 @@
                   "minimum": 0
                 }
               },
+              "required": ["mode", "precision"],
               "additionalProperties": false
             }
           ]

--- a/codecs/zarrs.zfp/schema.json
+++ b/codecs/zarrs.zfp/schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "zarrs.zfp"
+        },
+        "configuration": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "const": "reversible"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "const": "expert"
+                },
+                "minbits": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxbits": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "maxprec": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "minexp": {
+                  "type": "integer"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "const": "fixed_accuracy"
+                },
+                "tolerance": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "const": "fixed_rate"
+                },
+                "rate": {
+                  "type": "number"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "mode": {
+                  "const": "fixed_precision"
+                },
+                "precision": {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": ["name", "configuration"],
+      "additionalProperties": false
+    }
+  ]
+}


### PR DESCRIPTION
I intend to release this codec with the next [`zarrs`](https://crates.io/crates/zarrs) release. If this codec configuration and implementation is not controversial, it would be good if it were just named `zfp`?

Previous `zarrs` releases had some differences from this spec:
- `"name": "https://codec.zarrs.dev/array_to_bytes/zfp"`
- Supports a `write_header` parameter that I would prefer to remove

The inclusion of a `write_header` parameter might be worthy of discussion though. If it were present, then this codec is fully compatible with data encoded with `zfpy` in Zarr V2 / `numcodecs.zfpy` in Zarr V3 with just a change of metadata. I support `zfpy` independently in `zarrs`, although it is the same underlying codec implementation.