### PR TITLE
Add json data type

### DIFF
--- a/codecs/vlen-utf8/README.md
+++ b/codecs/vlen-utf8/README.md
@@ -27,12 +27,19 @@ For example, the array metadata below specifies that the array contains variable
 
 This is a `array -> bytes` codec.
 
-This codec is only compatible with the [`"string"`](../../data-types/string/README.md) data type.
+This codec is only compatible with the
+[`"string"`](../../data-types/string/README.md) and
+[`"json"`](../../data-types/json/README.md) data types.
 
 In the encoded format, each chunk is prefixed with a 32-bit little-endian unsigned integer (u32le) that specifies the number of elements in the chunk.
 This prefix is followed by a sequence of encoded elements in lexicographical order.
 Each element in the sequence is encoded by a u32le representing the number of bytes followed by the bytes themselves.
-The bytes for each element are obtained by encoding the element as UTF8 bytes.
+
+For the `"string"` data type, the bytes for each element are obtained by
+encoding the element as UTF8 bytes.
+
+For the `"json"` data type, the bytes for each element are obtained by encoding
+the element as JSON (which is itself valid UTF8).
 
 See https://numcodecs.readthedocs.io/en/stable/other/vlen.html#vlenutf8 for details about the encoding.
 

--- a/data-types/json/README.md
+++ b/data-types/json/README.md
@@ -1,0 +1,33 @@
+# json data type
+
+Defines a data type for arbitrary JSON values.
+
+## Permitted fill values
+
+The value of the `fill_value` metadata may be any JSON value.
+
+## Example
+
+For example, the array metadata below specifies that the array contains JSON values:
+
+```json
+{
+    "data_type": "json",
+    "fill_value": {"some": "value"},
+    "codecs": [{
+        "name": "vlen-utf8"
+    }],
+}
+```
+
+## Notes
+
+Currently, this data type is only compatible with the [`"vlen-utf8"`](../../codecs/vlen-utf8/README.md) codec.
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* Jeremy Maitin-Shepard ([@jbms](https://github.com/jbms)), Google

--- a/data-types/json/schema.json
+++ b/data-types/json/schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "json"
+        },
+        "configuration": {
+          "type": "object",
+          "additionalProperties": false
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    { "const": "json" }
+  ]
+}


### PR DESCRIPTION
This defines a `json` data type and adds it as a supported data type to the `vlen-utf8` codec.

In my opinion it is a bit unfortunate that `vlen-utf8` and `vlen-bytes` were added as separate codecs rather than just using `vlen` for both.  In zarr v2 a separate identifier was needed because the data type for both was listed as "O" and therefore the real data type had to be determined based on the codec identifier.  In zarr v3 that problem does not exist.

In this PR I decided to just allow the `json` data type in the `vlen-utf8` codec, because encoded JSON is itself valid UTF-8.

Possible alternatives:
 - Add a new `vlen-json` codec instead.
 - Add a new `vlen` codec that will support `bytes`, `string`, and `json` and make `vlen-bytes` and `vlen-utf8` deprecated.