### PR TITLE
Define codec for LZW compression

### DIFF
--- a/codecs/lzw/README.md
+++ b/codecs/lzw/README.md
@@ -1,0 +1,37 @@
+# lzw codec
+
+Defines a `bytes -> bytes` codec that applies [LZW (Lempel-Ziv-Welch) compression](https://ieeexplore.ieee.org/document/1659158).
+
+## Codec name
+
+The value of the `name` member in the codec object MUST be `lzw`.
+
+## Configuration parameters
+
+None
+
+## Example
+
+For example, the array metadata below specifies that the array is compressed using the LZW method:
+
+```json
+{
+    "codecs": [{
+        "name": "lzw"
+    }]
+}
+```
+
+## Format and algorithm
+
+This is a `bytes -> bytes` codec.
+
+Encoding and decoding is performed using the algorithm defined in [Welch, "A Technique for High-Performance Data Compression," in Computer, vol. 17, no. 6, pp. 8-19, June 1984, doi: 10.1109/MC.1984.1659158](https://ieeexplore.ieee.org/document/1659158)
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+* [@cgohlke](https://github.com/cgohlke) in [imagecodecs](https://github.com/cgohlke/imagecodecs)

--- a/codecs/lzw/schema.json
+++ b/codecs/lzw/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "oneOf": [
+    {
+      "type": "object",
+      "properties": {
+        "name": {
+          "const": "lzw"
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": false
+    },
+    { "const": "lzw" }
+  ]
+}


### PR DESCRIPTION
I'm proposing adding an extension for LZW compression to enable Zarr format 3 support for imagecodecs (xref #15 )

cc @@cgohlke @d-v-b 