### PR TITLE
fix: typos in some `float8_*` dtype specs

### DIFF
--- a/data-types/float8_e3m4/README.md
+++ b/data-types/float8_e3m4/README.md
@@ -33,7 +33,7 @@ Encoded as a 1-byte value `0bSEEEMMMM`.  The `"endian"` parameter has no effect.
 ## See also
 
 - Python implementation available at https://pypi.org/project/ml-dtypes/
-- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `FloatE3M4`.
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `Float8E3M4`.
 
 ## Current maintainers
 

--- a/data-types/float8_e4m3/README.md
+++ b/data-types/float8_e4m3/README.md
@@ -37,7 +37,7 @@ Encoded as a 1-byte value `0bSEEEEMMM`.  The `"endian"` parameter has no effect.
   MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
 - Python implementation available at https://pypi.org/project/ml-dtypes/
 - Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as
-  `FloatE4M3`.
+  `Float8E4M3`.
 
 ## Current maintainers
 

--- a/data-types/float8_e5m2fnuz/README.md
+++ b/data-types/float8_e5m2fnuz/README.md
@@ -4,7 +4,7 @@ Defines an 8-bit floating point representation with:
 
 - 1 sign bit
 - 5 exponent bits, with bias of 16
-- 3 mantissa bits
+- 2 mantissa bits
 - Extended range: no infinity, NaN represented by `0b1000'0000`.
 - Subnormal numbers when biased exponent is 0.
 
@@ -40,7 +40,7 @@ Encoded as a 1-byte value `0bSEEEEEMM`.  The `"endian"` parameter has no effect.
 
 - Bit layout described by https://arxiv.org/abs/2206.02915
 - Python implementation available at https://pypi.org/project/ml-dtypes/
-- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `FloatE4M3`.
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `Float8E5M2FNUZ`.
 
 ## Current maintainers
 

--- a/data-types/float8_e8m0fnu/README.md
+++ b/data-types/float8_e8m0fnu/README.md
@@ -41,7 +41,7 @@ Encoded as a 1-byte value `0bEEEEEEEE`.  The `"endian"` parameter has no effect.
 - Defined as the *scale* format E8M0 by [OpenCompute
   MX](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf).
 - Python implementation available at https://pypi.org/project/ml-dtypes/
-- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `Float8E8M0FN`.
+- Implemented in [LLVM/MLIR](https://llvm.org/doxygen/APFloat_8h_source.html) as `Float8E8M0FNU`.
 
 ## Current maintainers
 


### PR DESCRIPTION
I also noted that `float8_e4m3fn` is not present