### PR TITLE
Proposal: Projection Attribute Extension for Zarr v3

### DIFF
--- a/attributes/geo/proj/README.md
+++ b/attributes/geo/proj/README.md
@@ -14,7 +14,7 @@ This specification defines a JSON object that encodes datum and coordinate refer
 
 The complete specification, including detailed documentation, JSON schema, examples, and implementation notes, is maintained in the [EOPF Data Model repository](https://github.com/EOPF-Explorer/data-model/tree/main/attributes/geo/proj).
 
-**Repository**: https://github.com/EOPF/eopf-explorer/data-model  
+**Repository**: https://github.com/EOPF-Explorer/data-model  
 **Specification Path**: `attributes/geo/proj/`
 
 ## Quick Reference


### PR DESCRIPTION
This PR introduces attribute extensions as a new extension point and adds the first attribute extension for coordinate reference system (CRS) metadata.

### Summary

- Creates new "Attributes" extension category
- Adds `geo:proj` attribute extension for CRS metadata
- Based on STAC Projection Extension v2.0.0
- Supports multiple CRS representations (EPSG codes, WKT2, PROJJSON)
- Handles multi-dimensional arrays with explicit spatial dimension identification

### Key Design Decisions

1. **New extension point**: Attributes join codecs, data types, etc. as standardizable components
2. **Hybrid spatial dimension identification**: Explicit `spatial_dimensions` with fallback to naming conventions
3. **Multiple CRS formats**: Support for EPSG codes, WKT2, and PROJJSON with defined precedence
4. **Inheritance**: Group-level CRS applies to child arrays unless overridden

### Files Changed

- `README.md` - Added Attributes to extension points list
- `attributes/README.md` - New file defining attribute extensions
- `attributes/projection/README.md` - Projection extension specification
- `attributes/projection/schema.json` - JSON schema for validation

### Testing Checklist

- [ ] Schema validates against example JSON
- [X] Schema formatted with `npx prettier -w **/schema.json`

### Related Discussions

- zarr-developers/geozarr-spec#20 (CRS encoding concerns)
- zarr-developers/geozarr-spec#90 (grid_mapping variables)
- zarr-developers/geozarr-spec#88 (attribute organization)
- zarr-developers/geozarr-spec#95 (JSON)

This extension provides a simple, standardized way to add CRS metadata to Zarr arrays without the complexity issues identified in GeoZarr discussions around CF conventions.

cc @d-v-b @vincentsarago @j08lue