### PR TITLE
struct: allow dtype field to be JSON object sans configuration

### DIFF
--- a/data-types/struct/README.md
+++ b/data-types/struct/README.md
@@ -268,7 +268,9 @@ Variable-length codecs (e.g. `vlen-utf8`) are not compatible with the
 
 ## Change log
 
-No changes yet.
+- Relaxed the JSON schema to permit field data types declared as a JSON
+  object without a `configuration` key, e.g. `{"name": "float64"}`
+  ([#63](https://github.com/zarr-developers/zarr-extensions/pull/63)).
 
 ## Current maintainers
 

--- a/data-types/struct/schema.json
+++ b/data-types/struct/schema.json
@@ -19,7 +19,7 @@
               "type": "object"
             }
           },
-          "required": ["name", "configuration"],
+          "required": ["name"],
           "additionalProperties": false
         }
       ]


### PR DESCRIPTION
This change makes the schema permit data types declared in the object-with-no-configuration form, e.g. `{"name": "float64"}`. Verbose but permitted by the spec.

We can minimize changes like this by settling on reusable JSON schemas for the Zarr v3 spec (xref https://github.com/zarr-developers/zarr-specs/pull/347)