### PR TITLE
Nanovdb codec

### DIFF
--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -1,6 +1,6 @@
 # nanovdb codec
 
-Defines an `array -> bytes` codec that encodes an array chunk as a
+Defines an `array -> bytes` codec that encodes an array chunk as one or more
 [NanoVDB](https://www.openvdb.org/documentation/doxygen/NanoVDB_MainPage.html)
 grid buffer.
 
@@ -30,25 +30,21 @@ The value of the `name` member in the codec object MUST be `nanovdb`.
 The `configuration` object is REQUIRED and all of its members are required. It
 is a closed set: implementations MUST NOT emit members other than those below.
 
-A NanoVDB buffer declares its own geometry and grid type, so decoders MUST take
-those from the buffer rather than from this configuration; MUST verify that they
-are consistent with the array metadata and with the members below; and MUST
-return an error on mismatch.
+Decoders MUST take grid geometry and grid type from the buffer rather than from
+this configuration, MUST verify both against the array metadata and the members
+below, and MUST return an error on mismatch.
 
-[`tree_config`](#tree_config) is the exception, because the buffer does not
-record it. A decoder MUST reject a declared `tree_config` it does not implement,
-and SHOULD check that the buffer's node byte spans agree with the declared
-branching factors wherever a level is non-empty.
+The buffer does not record [`tree_config`](#tree_config). A decoder MUST reject
+a declared `tree_config` it does not implement, and SHOULD check that the
+buffer's node byte spans agree with the declared branching factors wherever a
+level is non-empty.
 
 ### `dimension_roles`
 
-An array of role tokens, one per dimension of **this codec's input**, outermost
+An array of role tokens, one per dimension of this codec's input, outermost
 first. The input is the array chunk after any preceding `array -> array` codec
-has been applied, so when a [`transpose`](../transpose/README.md) precedes this
-codec the roles are listed in the transposed order, not the array's.
-Every dimension MUST be given a role explicitly. The codec never infers roles
-from the input's rank, from `dimension_names`, or from any convention layered
-above Zarr.
+has been applied. The length MUST equal the input rank; every dimension MUST be
+given a role explicitly.
 
 | role          | how this codec encodes the dimension                                                           |
 | ------------- | ---------------------------------------------------------------------------------------------- |
@@ -56,80 +52,56 @@ above Zarr.
 | `z`, `y`, `x` | A NanoVDB coordinate axis. These three dimensions are the tree's index space.                  |
 | `channel`     | Becomes the grid's value type: extent `1` a scalar grid, `3` a `Vec3` grid, `4` a `Vec4` grid. |
 
-The roles MUST appear in this order, and encoders and decoders MUST reject any
-other arrangement:
+The roles MUST appear in this order:
 
 ```
 [grid … grid]   z   y   x   [channel]
 ```
 
-That is: zero or more `grid` dimensions, outermost; then exactly one each of
-`z`, `y` and `x`, in that order; then at most one `channel` dimension, which
-MUST be the innermost (unit-stride) dimension. A `channel` dimension MUST have
-extent `1`, `3` or `4`, matching `grid_type` per
-[Supported data types](#supported-data-types); an array with no `channel`
-dimension is scalar, exactly as one with a `channel` dimension of extent `1`.
-The strict order above constrains this codec's input, not the array. An array
-whose dimensions are in any other order reaches it through a preceding
-[`transpose`](../transpose/README.md), which is permitted for exactly this
-purpose; see
-[Interaction with other codecs](#interaction-with-other-codecs). Since
-`transpose` defines its output dimension `i` to be its input dimension
-`order[i]`, the two line up as `dimension_roles[i]` ↔ array dimension
-`order[i]` — so `order` follows from the roles the array's dimensions are meant
-to carry, and an implementation MAY derive it. OME-Zarr `[t, c, z, y, x]` with
-`c = 3` gives `order: [0, 2, 3, 4, 1]`; an `[x, y, z]` array gives
-`order: [2, 1, 0]`.
+Zero or more `grid` dimensions, outermost; then exactly one each of `z`, `y` and
+`x`, in that order; then at most one `channel` dimension, which MUST be the
+innermost (unit-stride) dimension. Encoders and decoders MUST reject any other
+arrangement. A `channel` dimension MUST have extent `1`, `3` or `4`, matching
+`grid_type` per [Supported data types](#supported-data-types). No `channel`
+dimension is equivalent to a `channel` dimension of extent `1`.
 
-Note that with a `transpose` in the chain `dimension_roles` is **not**
-index-aligned with `shape`, `chunk_shape` or `dimension_names`, which are in
-the array's own order; `order` is the only thing relating them.
+Roles constrain this codec's input, not the array. An array in any other
+dimension order reaches it through a preceding
+[`transpose`](../transpose/README.md); see
+[Interaction with other codecs](#interaction-with-other-codecs). Because
+`transpose` defines its output dimension `i` to be its input dimension
+`order[i]`, `dimension_roles[i]` describes array dimension `order[i]`, and
+`dimension_roles` is then **not** index-aligned with `shape`, `chunk_shape` or
+`dimension_names`. OME-Zarr `[t, c, z, y, x]` with `c = 3` requires
+`order: [0, 2, 3, 4, 1]`; an `[x, y, z]` array requires `order: [2, 1, 0]`.
+
+A role states only how this codec encodes a dimension, never what it means: a
+`grid` dimension need not be time, nor a `channel` dimension vector components.
+Meaning belongs in `dimension_names` or a convention above Zarr.
 
 ### `grid_type`
 
 The NanoVDB `GridType` of the encoded grid: one of `Float`, `Double`, `Int16`,
 `Int32`, `Int64`, `UInt32`, `Mask`, `Fp4`, `Fp8`, `Fp16`, `FpN`, `Vec3f`,
-`Vec3d`, `Vec4f`, `Vec4d`. Not redundant with the array's `data_type`: the
-quantized types (`Fp4`, `Fp8`, `Fp16`, `FpN`) encode a `float32` array in fewer
-bits per voxel, and the vector types pair a `float32` or `float64` array with a
-`channel` dimension. See [Supported data types](#supported-data-types).
+`Vec3d`, `Vec4f`, `Vec4d`. Not derivable from the array's `data_type`: the
+quantized types (`Fp4`, `Fp8`, `Fp16`, `FpN`) encode a `float32` array at
+reduced precision, and the vector types pair a `float32` or `float64` array
+with a `channel` dimension. See
+[Supported data types](#supported-data-types).
 
 ### `tree_config`
 
 An array of the tree's node branching factors, as the `Log2Dim` of each level
 from the root side to the leaf. MUST be `[5, 4, 3]`, giving 8³ leaves, 128³
-lower internal nodes and 4096³ upper internal nodes. Every extent the
-[grid coherence](#grid-coherence-across-chunks) requirements refer to derives
-from this array: the leaf extent is `1 << tree_config[2]` and the lower
-internal node extent is `1 << (tree_config[1] + tree_config[2])`.
+lower internal nodes and 4096³ upper internal nodes. The leaf extent is
+`1 << tree_config[2]` and the lower internal node extent is
+`1 << (tree_config[1] + tree_config[2])`.
 
-`[5, 4, 3]` is the only registered configuration, for two reasons beyond its
-being OpenVDB's default:
-
-- It is the only one the official released NanoVDB implementation reads or
-  writes.
-- A reader cannot recover the configuration from the buffer. NanoVDB records
-  branching factors nowhere: not in the grid header, and not in the
-  `nanovdb::io` file header either, whose per-grid metadata carries node and
-  tile _counts_ rather than node dimensions. Counts do not determine the
-  `Log2Dim` values, and the arithmetic that would recover node sizes from them
-  breaks down for a level with no nodes — the sparse case this codec serves.
-  Wrapping the buffer in the file container is therefore not a way to make it
-  self-describing.
-
-The field is therefore declared explicitly rather than assumed, so that a
-reader can reject what it does not implement instead of misreading it, and so
-that another configuration can be registered later without ambiguity. Note
-that declaring it buys a clean rejection, not compatibility: because a NanoVDB
-reader's tree type is fixed when it is compiled, no amount of metadata makes
-another configuration readable by an implementation built for this one. Keeping
-the declaration in the array metadata rather than the buffer lets a decoder
-reject an array before fetching any chunk.
-
-Any future value MUST also have exactly three entries: NanoVDB's tree depth is
-not parameterized, and the
-[grid coherence](#grid-coherence-across-chunks) requirements assume the three
-levels above.
+`[5, 4, 3]` is the only registered configuration, and the only one the released
+NanoVDB implementation reads or writes. Branching factors appear in neither the
+grid header nor the `nanovdb::io` file header, which records node and tile
+_counts_ only. Any future value MUST also have exactly three entries: NanoVDB's
+tree depth is not parameterized.
 
 ### `index_space`
 
@@ -142,9 +114,7 @@ used.
 
 One of `none`, `bbox`, `minmax`, `all`: the per-node statistics the grid
 carries. `bbox` includes active bounding boxes; `minmax` adds per-node minimum
-and maximum values; `all` adds average and standard deviation. Empty-space
-skipping and range estimation depend on `minmax` or `all`; see
-[Reader pass-through](#reader-pass-through).
+and maximum values; `all` adds average and standard deviation.
 
 ### `lossless`
 
@@ -163,18 +133,17 @@ exactly equal to the background. See
 ## Supported chunk shapes
 
 The chunk's rank MUST equal the length of
-[`dimension_roles`](#dimension_roles), and each dimension is constrained by its
+[`dimension_roles`](#dimension_roles). Each dimension is constrained by its
 role:
 
-| role      | chunk extent                                                                                                                                |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `grid`    | Any extent. The chunk's buffer holds one grid per index, so the grid count is the product of the chunk extents along all `grid` dimensions. |
-| `z y x`   | Constrained by requirements 2 and 3 of [grid coherence](#grid-coherence-across-chunks): leaf-aligned, and node-aligned where practical.     |
-| `channel` | MUST equal the array extent along that dimension, so that no chunk holds a partial vector (requirement 6).                                  |
+| role      | chunk extent                                                                                                                        |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `grid`    | Any extent. The buffer holds one grid per index, so the grid count is the product of the chunk extents along all `grid` dimensions. |
+| `z y x`   | Leaf-aligned, and node-aligned where practical: requirements 2 and 3 of [grid coherence](#grid-coherence-across-chunks).            |
+| `channel` | MUST equal the array extent along that dimension (requirement 6).                                                                   |
 
-The three spatial dimensions map to NanoVDB coordinates with the innermost
-being the `x` axis. Writing `t` for the index along a single `grid` dimension
-and `c` for the `channel` index:
+The innermost spatial dimension is the NanoVDB `x` axis. Writing `t` for the
+index along a single `grid` dimension and `c` for the `channel` index:
 
 | `dimension_roles`                | chunk shape           | grid value | grid within buffer | NanoVDB coordinate                                      |
 | -------------------------------- | --------------------- | ---------- | ------------------ | ------------------------------------------------------- |
@@ -196,7 +165,7 @@ array-to-bytes codec within the
 
 ## Supported data types
 
-Scalar grids take an array with no `channel` dimension, or a `channel`
+Scalar grids take an input with no `channel` dimension, or a `channel`
 dimension of extent `1`:
 
 | Zarr `data_type` | `grid_type`                          | Notes                                         |
@@ -218,10 +187,8 @@ Vector grids take a `channel` dimension of extent `c`:
 | `float32`        | `4` | `Vec4f`     |
 | `float64`        | `4` | `Vec4d`     |
 
-A `channel` extent of `2`, or greater than `4`, has no NanoVDB counterpart and
-MUST be rejected. An axis of that width whose values belong to one voxel has no
-representation in this codec; an axis whose indices are independent fields
-SHOULD be given the `grid` role instead, which places each on its own grid.
+A `channel` extent of `2`, or greater than `4`, MUST be rejected. Such an axis
+SHOULD be given the `grid` role instead, placing each index on its own grid.
 
 Data types not listed above are supported only through promotion:
 implementations MAY promote a narrower data type to a wider `grid_type` (for
@@ -230,27 +197,22 @@ written and MUST NOT promote across the scalar/vector boundary. Zarr data types
 with no NanoVDB counterpart (complex and variable-length types among them) are
 not supported.
 
-Two NanoVDB grid families are out of scope: matrix grids, which would require
-two `channel` dimensions (`[Z, Y, X, 3, 3]`) and therefore a revision of
-[`dimension_roles`](#dimension_roles), which permits at most one; and integer
-vector grids
-(`Vec3i` and similar), a plausible future addition pending confirmation of
-which are available across the NanoVDB versions this codec targets.
+Matrix grids, which would need two `channel` dimensions, and integer vector
+grids (`Vec3i` and similar) are out of scope.
 
-For vector grids, two consequences of Zarr's `fill_value` being a scalar:
+For vector grids, `fill_value` being a scalar means:
 
 - The grid's background value MUST be the vector all of whose components equal
-  `fill_value`; a background with unequal components cannot be expressed in the
-  array metadata and MUST NOT be written.
+  `fill_value`. A background with unequal components MUST NOT be written.
 - A voxel is active or inactive as a whole. An encoder MUST treat a voxel as
   non-background if _any_ component differs from `fill_value` by more than
   `tolerance`.
 
 > [!NOTE]
-> **Open question for review.** `stats: minmax` is not obviously well defined
-> for vector grids, which have no natural total order. Componentwise minima and
-> maxima are the plausible reading, but this proposal does not yet fix it; the
-> conservative option is to restrict vector grids to `stats: none` or `bbox`.
+> **Open question for review.** `stats: minmax` is undefined for vector grids,
+> which have no natural total order. Componentwise minima and maxima are the
+> plausible reading; the conservative option is to restrict vector grids to
+> `stats: none` or `bbox`.
 
 ## Format and algorithm
 
@@ -262,85 +224,60 @@ NanoVDB's grid builders, written verbatim.
 - The buffer MUST be little-endian and MUST begin with a valid NanoVDB grid
   magic number and version header. The magic numbers, version encoding, and
   structure layouts are defined normatively by
-  [`nanovdb/NanoVDB.h`](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/nanovdb/nanovdb/NanoVDB.h);
-  this document does not restate them.
+  [`nanovdb/NanoVDB.h`](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/nanovdb/nanovdb/NanoVDB.h).
 - The buffer MUST NOT be wrapped in the `nanovdb::io` file container, whose
-  file headers and optional compression duplicate the Zarr chunk key and
-  `bytes -> bytes` codecs respectively. Nothing is given up by omitting it: a
-  raw grid buffer identifies itself with its own magic number, distinct from
-  the container's, and NanoVDB reads raw buffers directly — including
-  addressing one grid of a multi-grid buffer. The container's remaining fields
-  are a name lookup key and geometry that is recoverable from the grid itself.
-  It records no tree configuration either; see
-  [`tree_config`](#tree_config).
-- Every grid's background value MUST equal the array's `fill_value`, so that
-  inactive voxels decode identically across every chunk.
+  magic number differs from a raw grid buffer's.
+- Every grid's background value MUST equal the array's `fill_value`.
 
 #### Grid enumeration
 
-An array whose [`dimension_roles`](#dimension_roles) contain no `grid`
+An input whose [`dimension_roles`](#dimension_roles) contain no `grid`
 dimension encodes one grid per chunk. Otherwise the chunk's buffer holds
-`mGridCount` grids, laid out exactly as `nanovdb::mergeGrids` produces them:
+`mGridCount` grids, laid out as `nanovdb::mergeGrids` produces them:
 
-- The grid count MUST equal the product of the chunk's extents along its
-  `grid` dimensions, and MUST be recorded as `mGridCount` in **every** grid's
-  header, not only the first.
-- Grids MUST be stored consecutively, each beginning where the previous one
-  ends: grid `n + 1` starts `mGridSize` bytes after grid `n`. A reader locates
-  grid `n` by summing the preceding grids' `mGridSize`, which is how NanoVDB's
-  own `GridHandle` indexes a multi-grid buffer.
-- Grid `n` MUST record `mGridIndex` equal to `n`, and `n` MUST be the C-order
+- The grid count MUST equal the product of the chunk's extents along its `grid`
+  dimensions, and MUST be recorded as `mGridCount` in **every** grid's header,
+  not only the first.
+- Grids MUST be stored consecutively, grid `n + 1` beginning `mGridSize` bytes
+  after grid `n`. A reader locates grid `n` by summing the preceding grids'
+  `mGridSize`.
+- Grid `n` MUST record `mGridIndex` equal to `n`, where `n` is the C-order
   (row-major, last `grid` dimension varying fastest) ravel of the chunk-local
-  indices along the `grid` dimensions. This is what makes a grid addressable
-  from array coordinates alone.
-- `mGridName` is not authoritative: readers MUST resolve a grid by index, never
-  by name, since nothing constrains names to be unique or populated. Writers
-  MAY set names for the benefit of tools outside Zarr.
-
-Each grid is an independent tree with its own topology, so a `grid` dimension
-imposes no relationship between the active sets of successive indices — which
-is what makes it the right role for a time axis. The per-array uniformity of
-requirement 5 still applies to all of them.
+  indices along the `grid` dimensions.
+- Readers MUST resolve a grid by index, never by `mGridName`, which is
+  unconstrained. Writers MAY set names.
 
 ### Grid coherence across chunks
 
-Encoding each chunk as an unrelated grid — its own origin, alignment, and tree
-shape — would leave readers unable to treat the chunks as parts of one
-hierarchy. The following requirements prevent that. An array using this codec
-MUST satisfy all of them, and each is checkable from the array metadata and
-chunk buffers alone.
+An array using this codec MUST satisfy all of the following. Each is checkable
+from the array metadata and chunk buffers alone.
 
 1. **One index space.** Each chunk's grids MUST express voxel coordinates in
-   the global index space of this codec's input (the `z`, `y`, `x` indices
+   the global index space of this codec's input: the `z`, `y`, `x` indices
    `[k, j, i]` occupy NanoVDB coordinate `(i, j, k)` regardless of which chunk
-   holds them); grids MUST NOT be rebased to a chunk-local origin. Chunks of a
-   region then compose by union, and a writer can produce them by splitting one
-   global grid. A preceding [`transpose`](../transpose/README.md) composes a
-   constant permutation onto this mapping without weakening it: the array
-   coordinate is recovered from the NanoVDB coordinate by `order`, which is
-   metadata rather than per-chunk state.
+   holds them. Grids MUST NOT be rebased to a chunk-local origin. A preceding
+   [`transpose`](../transpose/README.md) composes a constant permutation onto
+   this mapping: the array coordinate is recovered from the NanoVDB coordinate
+   by `order`.
 
-2. **Leaf-aligned chunk grid.** The chunk extent along each of the `z`, `y`
-   and `x` dimensions, and the chunk grid origin in each of them, MUST be an
+2. **Leaf-aligned chunk grid.** The chunk extent along each of the `z`, `y` and
+   `x` dimensions, and the chunk grid origin in each of them, MUST be an
    integer multiple of the leaf extent `1 << tree_config[2]` (8 for
    `[5, 4, 3]`), so that no leaf node straddles a chunk boundary.
 
 3. **Node-aligned chunk shape (recommended).** The `z`, `y` and `x` chunk
    extents SHOULD additionally be an integer multiple of, or an integer divisor
    of, the lower internal node extent
-   `1 << (tree_config[1] + tree_config[2])` (128 for `[5, 4, 3]`). A chunk that
-   is an exact node extent is a clean subtree with a dense top level,
-   addressable without searching the root node's tile table; other shapes
-   satisfying requirement 2 remain conformant at the cost of a root-level
-   lookup per traversal.
+   `1 << (tree_config[1] + tree_config[2])` (128 for `[5, 4, 3]`). A chunk of
+   exactly one node extent is a subtree with a dense top level, traversable
+   without searching the root node's tile table; other shapes satisfying
+   requirement 2 are conformant but require a root-level lookup.
 
-   Requirements 2 and 3 constrain only the three spatial dimensions. A
-   `channel` dimension is governed by requirement 6, and a `grid` dimension by
-   requirement 7; neither has any alignment constraint, because neither is part
-   of the tree's index space. Where a `transpose` precedes this codec, the
-   extents these requirements constrain are those of the array dimensions
-   carrying the `z`, `y` and `x` roles — `chunk_shape[order[i]]` for the
-   relevant `i` — since `transpose` permutes extents without changing them.
+   Requirements 2 and 3 constrain only the three spatial dimensions; a
+   `channel` dimension is governed by requirement 6 and a `grid` dimension by
+   requirement 7. Where a `transpose` precedes this codec the constrained
+   extents are `chunk_shape[order[i]]` for the relevant `i`, since `transpose`
+   permutes extents without changing them.
 
 4. **Disjoint coverage.** Each of a chunk's grids MUST contain active voxels
    only within that chunk's spatial bounds, so for every index along the `grid`
@@ -348,10 +285,7 @@ chunk buffers alone.
    active sets.
 
 5. **Uniform configuration.** Every grid of every chunk of an array MUST use
-   the same `grid_type`, `tree_config`, `stats`, and background value, letting
-   a reader specialize its traversal (including compiling a shader) once per
-   array. This is what keeps a `grid` dimension cheap: the grids differ in
-   topology and values, never in layout.
+   the same `grid_type`, `tree_config`, `stats`, and background value.
 
 6. **Whole vectors per chunk.** The chunk extent along a `channel` dimension
    MUST equal the array extent along it, so that no chunk holds a partial
@@ -360,13 +294,7 @@ chunk buffers alone.
 7. **Grids addressable by index.** A chunk's grid count MUST equal the product
    of its extents along the `grid` dimensions, and grid `n` of the buffer MUST
    correspond to the C-order ravel of the chunk-local `grid` indices, as
-   specified in [Grid enumeration](#grid-enumeration). A reader can then map an
-   array coordinate to a grid without inspecting grid names or decoding any
-   other chunk.
-
-Requirement 3 is a recommendation because its tradeoff is reader-side cost
-rather than correctness; the rest are what allow the chunks of an array to be
-treated as one logical grid without inspecting every chunk.
+   specified in [Grid enumeration](#grid-enumeration).
 
 ### Sparsity and losslessness
 
@@ -375,83 +303,44 @@ Decoding produces the grid's active values composited over the array's
 
 - With `lossless: true` (`tolerance: 0`), an encoder MUST leave a voxel
   inactive only if it exactly equals the background; decoding reproduces the
-  input array bit-for-bit.
+  input bit-for-bit.
 - With `lossless: false` and `tolerance: t > 0`, an encoder MAY additionally
-  leave inactive any voxel within `t` of the background — the useful case for
-  noisy data, recorded in the metadata rather than left as an encoder artifact.
+  leave inactive any voxel within `t` of the background.
 - The quantized grid types are lossy in the value domain independently of
   `tolerance`.
 
 `tolerance` is a topology threshold, not a value threshold: voxels that remain
-active are stored at full precision (subject to `grid_type`).
+active are stored at full precision, subject to `grid_type`.
 
 ## Interaction with other codecs
 
-[`transpose`](../transpose/README.md) is the one `array -> array` codec that may
-precede this one. No other may, and implementations SHOULD reject such a chain
-when the array metadata is parsed.
+[`transpose`](../transpose/README.md) MAY precede this codec. No other
+`array -> array` codec may, and implementations SHOULD reject such a chain when
+the array metadata is parsed:
 
-### Why `transpose` is permitted
+- [`reshape`](../reshape/README.md) does not preserve dimension identity, so
+  no role describes its output. Composing it with `transpose` does not make it
+  conformant.
+- Value-domain codecs, [`cast_value`](../cast_value/README.md) and
+  [`scale_offset`](../scale_offset/README.md) among them, would leave grid
+  values and background disagreeing with `data_type` and `fill_value`.
 
-`transpose` is a pure permutation of dimension indices: rank-preserving,
-exactly invertible, and declared in full by its `order`. It therefore does not
-weaken any [grid coherence](#grid-coherence-across-chunks) requirement — the
-tie between array indices and NanoVDB coordinates is composed with a constant
-permutation rather than broken — and it is what lets a strict role order
-coexist with whatever dimension order an array wants; see
-[`dimension_roles`](#dimension_roles).
-
-The concern that applies to `array -> array` codecs in general is that they
-decode _after_ the `array -> bytes` codec, so a reader taking the pass-through
-path never materializes a dense array for them to act on. For `transpose` this
-costs nothing: the permutation is a per-array constant, so such a reader folds
-it into its coordinate mapping instead of applying it to data. This is
-normative, not merely an option — see
-[Reader pass-through](#reader-pass-through).
-
-### Why the others are not
-
-1. [`reshape`](../reshape/README.md) splits and merges dimensions, preserving
-   only C-order element order. Dimension identity does not survive it, so there
-   is no dimension for a role to describe and requirement 1 has nothing to tie
-   NanoVDB coordinates to. Combining it with `transpose` does not help: the
-   composed operation is still not a permutation.
-2. Value-domain codecs such as [`cast_value`](../cast_value/README.md) and
-   [`scale_offset`](../scale_offset/README.md) transform every voxel. Unlike a
-   permutation these cannot be folded into a coordinate mapping, so permitting
-   them would forfeit the pass-through path for exactly the arrays this codec
-   serves — and would leave a grid whose values and background do not match the
-   array's `fill_value`. Their effect belongs in how the array was written.
-
-`bytes -> bytes` codecs compose freely and are the right place for general
-compression and checksums.
+`bytes -> bytes` codecs compose freely.
 
 ## Reader pass-through
 
-Because the encoded buffer is already a pointer-free spatial index, a reader
-MAY keep it rather than decode it to a dense array — including handing it to a
-GPU as-is and traversing it in a shader. The coherence requirements make this
-safe without inspecting the whole array: traversal is specialized once per
-array (requirement 5), chunks are addressed without coordinate arithmetic (1),
-no leaf spans a chunk boundary (2), and the root-level search can be skipped
-when requirement 3 holds. Such readers benefit from `stats` being `minmax` or
-`all`, which enables skipping subtrees outside the value range of interest;
-encoders targeting them SHOULD write those rather than `none`.
+A reader MAY retain the buffer rather than decode it to a dense array, and
+traverse it directly. Such a reader skips the `array -> array` decode stage, so
+it MUST compose the permutation of any preceding
+[`transpose`](../transpose/README.md) into its own coordinate mapping.
 
-Taking this path means skipping the `array -> array` decode stage, which would
-otherwise have undone a preceding [`transpose`](../transpose/README.md). A
-reader that does so MUST compose that permutation into its own coordinate
-mapping, so that a coordinate in the array's dimension order still resolves to
-the same voxel it would have through a full decode. Since `order` is a
-per-array constant this is a relabelling of axes and not work per voxel, but
-omitting it silently returns transposed results.
-
-Everything else in this section is non-normative.
+This is most useful for direct GPU rendering applications, and skipping subtrees by value range requires `stats` of `minmax` or `all`;
+encoders targeting such readers SHOULD write one of those rather than `none`.
 
 ## Examples
 
-A `float32` volume in leaf- and node-aligned 128³ chunks, losslessly sparsified
-against a background of `0.0`, with per-node min/max statistics:
+`float32`, leaf- and node-aligned 128³ chunks, lossless, with per-node
+min/max:
 
 ```json
 {
@@ -480,7 +369,7 @@ against a background of `0.0`, with per-node min/max statistics:
 }
 ```
 
-A segmentation mask, storing topology only:
+A segmentation mask, topology only:
 
 ```json
 {
@@ -501,7 +390,7 @@ A segmentation mask, storing topology only:
 }
 ```
 
-Thresholded fluorescence, quantized and sparsified with a recorded tolerance:
+Quantized and sparsified with a recorded tolerance:
 
 ```json
 {
@@ -523,9 +412,8 @@ Thresholded fluorescence, quantized and sparsified with a recorded tolerance:
 }
 ```
 
-A sparse `float32` displacement field shaped `[Z, Y, X, C]` with `C = 3`,
-encoded as a `Vec3f` grid; the `channel` dimension is innermost and covered in
-full by the chunk shape, so every chunk holds whole vectors:
+A `[Z, Y, X, C]` displacement field with `C = 3` as a `Vec3f` grid; the chunk
+covers `channel` in full:
 
 ```json
 {
@@ -554,11 +442,8 @@ full by the chunk shape, so every chunk holds whole vectors:
 }
 ```
 
-A time series of scalar volumes shaped `[T, Z, Y, X]`. The leading dimension
-takes the `grid` role, so each chunk's buffer holds four grids -- one per
-timepoint -- whose topologies are unrelated to each other. Nothing here is
-specific to time: the same layout serves an ensemble index or a set of
-independent fields, and `dimension_names` is where the meaning is recorded.
+A `[T, Z, Y, X]` series with the leading dimension in the `grid` role: four
+grids per chunk buffer.
 
 ```json
 {
@@ -588,9 +473,7 @@ independent fields, and `dimension_names` is where the meaning is recorded.
 }
 ```
 
-The same volumes with a three-component vector value per voxel, shaped
-`[T, Z, Y, X, C]`: `grid` outermost, `channel` innermost, and the chunk covers
-the `channel` dimension in full.
+The same with a three-component value per voxel, `[T, Z, Y, X, C]`:
 
 ```json
 {
@@ -620,11 +503,9 @@ the `channel` dimension in full.
 }
 ```
 
-An OME-Zarr style array shaped `[T, C, Z, Y, X]` with `C = 3`, whose three
-components belong to one voxel. A `transpose` moves the channel axis innermost
-so that this codec's input is `[t, z, y, x, c]`; each timepoint becomes one
-`Vec3f` grid. Note that `dimension_names` is in the array's order while
-`dimension_roles` is in the transposed order, and `order` relates them:
+An OME-Zarr `[T, C, Z, Y, X]` array with `C = 3`, where `transpose` makes this
+codec's input `[t, z, y, x, c]`. `dimension_names` is in the array's order and
+`dimension_roles` in the transposed order; `order` relates them:
 
 ```json
 {
@@ -663,21 +544,16 @@ expected decoded values and active/inactive topology.
 
 ## Interoperability and compatibility
 
-- The encoded buffer is a plain NanoVDB grid, readable by NanoVDB and any tool
-  built on it, independently of Zarr — once the `bytes -> bytes` stage has been
-  undone. Since compression is both recommended and effective here, a stored
-  chunk is generally not a NanoVDB buffer as it sits: reaching one means
-  running the Zarr decode chain, or writing the array with no `bytes -> bytes`
-  codec.
+- The buffer is a plain NanoVDB grid, readable by NanoVDB independently of Zarr
+  once the `bytes -> bytes` stage has been undone. With a compressor in the
+  chain a stored chunk is not a NanoVDB buffer as it sits.
 - Grids can be produced from OpenVDB grids with `nanovdb::createNanoGrid`, and
-  from dense arrays with NanoVDB's build tools. OpenVDB's own `.vdb`
-  serialization is _not_ interchangeable with a NanoVDB buffer and must be
-  converted.
-- NanoVDB buffers carry a version and declare their grid type, so a reader can
-  detect a buffer written by a newer NanoVDB, or holding a value type it does
-  not handle, and fail cleanly. They are not self-describing about the tree
-  configuration, which is why [`tree_config`](#tree_config) is recorded in the
-  array metadata.
+  from dense arrays with NanoVDB's build tools. OpenVDB's `.vdb` serialization
+  is not interchangeable with a NanoVDB buffer and must be converted.
+- A buffer carries a version and declares its grid type, so a reader can reject
+  a buffer written by a newer NanoVDB or holding a value type it does not
+  handle. It does not declare its tree configuration; see
+  [`tree_config`](#tree_config).
 - Reference implementation: in progress, targeting a Zarr reader that passes
   the buffer through to a GPU without densifying it.
 

--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -10,8 +10,8 @@ sparse voxels are stored in a shallow tree. For volumes that are mostly
 background (masks, sparse labels, level sets, distance fields, sparse vector
 fields), the buffer is both a compact encoding and a spatial index that a reader
 can traverse directly. This codec constrains how each chunk maps to a grid so
-that the grids of all chunks share one index space and node lattice; see
-[Grid coherence across chunks](#grid-coherence-across-chunks).
+that the grids of all chunks share one node lattice and compose into one logical
+volume; see [Grid coherence across chunks](#grid-coherence-across-chunks).
 
 > This document is a proposed extension. It is licensed under the
 > [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
@@ -110,12 +110,6 @@ grid header nor the `nanovdb::io` file header, which records node and tile
 _counts_ only. Any future value MUST also have exactly three entries: NanoVDB's
 tree depth is not parameterized.
 
-### `index_space`
-
-One of `global` or `chunk_local`: whether each chunk's grid uses the array's
-global index coordinates or is rebased to the chunk's own origin. `global` is
-REQUIRED for [grid coherence](#grid-coherence-across-chunks) and SHOULD be used.
-
 ### `stats`
 
 One of `none`, `bbox`, `minmax`, `all`: the per-node statistics the grid
@@ -193,9 +187,8 @@ its own. NanoVDB places red in the lowest byte, and the `channel` index gives
 the component: `0` red, `1` green, `2` blue, `3` alpha. With an extent of `3` an
 encoder MUST write an alpha of `255`, and a decoder MUST discard the alpha byte,
 so a three-channel array still round-trips exactly. The background is the word
-whose red, green and blue bytes all equal
-`fill_value`, with alpha `255` at an extent of `3` and `fill_value` at an extent
-of `4`.
+whose red, green and blue bytes all equal `fill_value`, with alpha `255` at an
+extent of `3` and `fill_value` at an extent of `4`.
 
 A `uint8` array is `UInt8` when it has no `channel` dimension and `RGBA8` when
 it has one of extent `3` or `4`; this is why `grid_type` is declared rather than
@@ -254,10 +247,14 @@ grids, laid out as `nanovdb::mergeGrids` produces them:
 An array using this codec MUST satisfy all of the following. Each is checkable
 from the array metadata and chunk buffers alone.
 
-1. **One index space.** Each chunk's grids MUST express voxel coordinates in the
-   global index space of this codec's input: the `z`, `y`, `x` indices
-   `[k, j, i]` occupy NanoVDB coordinate `(i, j, k)` regardless of which chunk
-   holds them. Grids MUST NOT be rebased to a chunk-local origin.
+1. **Chunk-local coordinates, one upper node per grid.** A grid MUST place its
+   chunk's first voxel at NanoVDB coordinate `(0, 0, 0)`: the chunk-local `z`,
+   `y`, `x` indices `[k, j, i]` occupy NanoVDB coordinate `(i, j, k)`. A reader
+   recovers a global coordinate by adding the chunk origin, which it already
+   computed in order to locate the chunk.
+
+   The spatial chunk extents MUST therefore not exceed the upper internal node
+   extent (4096 maximum chunk size for `[5, 4, 3]`,  `1 << (tree_config[0] + tree_config[1] + tree_config[2])` in general), so that every grid has exactly **one** upper node, whose origin is `(0, 0, 0)` and which the root reaches through a single tile with key `0`.
 
 2. **Leaf-aligned chunk grid.** The chunk extent along each of the `z`, `y` and
    `x` dimensions, and the chunk grid origin in each of them, MUST be an integer
@@ -267,10 +264,7 @@ from the array metadata and chunk buffers alone.
 3. **Node-aligned chunk shape (recommended).** The `z`, `y` and `x` chunk
    extents SHOULD additionally be an integer multiple of, or an integer divisor
    of, the lower internal node extent `1 << (tree_config[1] + tree_config[2])`
-   (128 for `[5, 4, 3]`). A chunk of exactly one node extent is a subtree with a
-   dense top level, traversable without searching the root node's tile table;
-   other shapes satisfying requirement 2 are conformant but require a root-level
-   lookup.
+   (128 for `[5, 4, 3]`), so that no lower internal node is only partly covered.
 
 4. **Disjoint coverage.** Each of a chunk's grids MUST contain active voxels
    only within that chunk's spatial bounds, so for every index along the `grid`
@@ -293,7 +287,7 @@ A voxel is active if and only if its value differs from the array's
 Activity is therefore fully determined by the array and its `fill_value`. An
 encoder has no discretion, two conformant encoders produce the same active set,
 and decoding reproduces the input bit-for-bit for every non-quantized
-`grid_type`. 
+`grid_type`.
 
 Choosing which voxels to store is the writer's business, not the codec's: to
 drop a voxel write `fill_value` into it before encoding.
@@ -355,7 +349,6 @@ readers SHOULD write one of those rather than `none`.
         "dimension_roles": ["z", "y", "x"],
         "grid_type": "Float",
         "tree_config": [5, 4, 3],
-        "index_space": "global",
         "stats": "minmax"
       }
     },
@@ -399,7 +392,6 @@ A segmentation mask, topology only:
         "dimension_roles": ["z", "y", "x"],
         "grid_type": "Mask",
         "tree_config": [5, 4, 3],
-        "index_space": "global",
         "stats": "bbox"
       }
     }
@@ -436,7 +428,6 @@ Quantized to 16 bits per voxel:
         "dimension_roles": ["z", "y", "x"],
         "grid_type": "Fp16",
         "tree_config": [5, 4, 3],
-        "index_space": "global",
         "stats": "all"
       }
     },
@@ -481,7 +472,6 @@ covers `channel` in full:
         "dimension_roles": ["z", "y", "x", "channel"],
         "grid_type": "Vec3f",
         "tree_config": [5, 4, 3],
-        "index_space": "global",
         "stats": "bbox"
       }
     },
@@ -526,7 +516,6 @@ grids per chunk buffer.
         "dimension_roles": ["grid", "z", "y", "x"],
         "grid_type": "Float",
         "tree_config": [5, 4, 3],
-        "index_space": "global",
         "stats": "minmax"
       }
     },
@@ -570,7 +559,6 @@ The same with a three-component value per voxel, `[T, Z, Y, X, C]`:
         "dimension_roles": ["grid", "z", "y", "x", "channel"],
         "grid_type": "Vec3f",
         "tree_config": [5, 4, 3],
-        "index_space": "global",
         "stats": "bbox"
       }
     },
@@ -622,7 +610,6 @@ codec's input `[t, z, y, x, c]`. `dimension_names` is in the array's order and
         "dimension_roles": ["grid", "z", "y", "x", "channel"],
         "grid_type": "Vec3f",
         "tree_config": [5, 4, 3],
-        "index_space": "global",
         "stats": "bbox"
       }
     },

--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -5,20 +5,19 @@ Defines an `array -> bytes` codec that encodes an array chunk as one or more
 grid buffer.
 
 NanoVDB is the linearized, pointer-free serialization of an
-[OpenVDB](https://www.openvdb.org/) tree, in which regions holding a single
-repeated value are stored once as a tile rather than as voxels. For volumes
-that are mostly background (masks, sparse labels, level sets, distance fields,
-sparse vector fields), the buffer is both a compact encoding and a spatial
-index that a reader can traverse directly. This codec constrains how each
-chunk maps to a grid so that the grids of all chunks share one index space and
-node lattice; see [Grid coherence across chunks](#grid-coherence-across-chunks).
+[OpenVDB](https://www.openvdb.org/) tree, in which the locations and values of
+sparse voxels are stored in a shallow tree. For volumes that are mostly
+background (masks, sparse labels, level sets, distance fields, sparse vector
+fields), the buffer is both a compact encoding and a spatial index that a reader
+can traverse directly. This codec constrains how each chunk maps to a grid so
+that the grids of all chunks share one index space and node lattice; see
+[Grid coherence across chunks](#grid-coherence-across-chunks).
 
 > This document is a proposed extension. It is licensed under the
 > [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
 
-> [!NOTE]
-> **Status: draft**, opened to solicit feedback. The reference implementation
-> is in progress; see
+> [!NOTE] **Status: draft**, opened to solicit feedback. The reference
+> implementation is in progress; see
 > [Interoperability and compatibility](#interoperability-and-compatibility).
 
 ## Codec name
@@ -75,6 +74,13 @@ dimension order reaches it through a preceding
 `dimension_names`. OME-Zarr `[t, c, z, y, x]` with `c = 3` requires
 `order: [0, 2, 3, 4, 1]`; an `[x, y, z]` array requires `order: [2, 1, 0]`.
 
+Most OME-Zarr arrays need no transpose. A `c` axis of independent channels —
+what that axis conventionally holds — takes the `grid` role, and
+`[t, c, z, y, x]` as `["grid", "grid", "z", "y", "x"]` is already in canonical
+order, giving one grid per `(t, c)` pair. A transpose is needed only when `c`
+holds the vector components of a single quantity, so that it must take the
+`channel` role and move innermost.
+
 A role states only how this codec encodes a dimension, never what it means: a
 `grid` dimension need not be time, nor a `channel` dimension vector components.
 Meaning belongs in `dimension_names` or a convention above Zarr.
@@ -82,11 +88,12 @@ Meaning belongs in `dimension_names` or a convention above Zarr.
 ### `grid_type`
 
 The NanoVDB `GridType` of the encoded grid: one of `Float`, `Double`, `Int16`,
-`Int32`, `Int64`, `UInt32`, `Mask`, `Fp4`, `Fp8`, `Fp16`, `FpN`, `Vec3f`,
-`Vec3d`, `Vec4f`, `Vec4d`. Not derivable from the array's `data_type`: the
-quantized types (`Fp4`, `Fp8`, `Fp16`, `FpN`) encode a `float32` array at
-reduced precision, and the vector types pair a `float32` or `float64` array
-with a `channel` dimension. See
+`Int32`, `Int64`, `UInt8`, `UInt32`, `Mask`, `Fp4`, `Fp8`, `Fp16`, `FpN`,
+`Vec3f`, `Vec3d`, `Vec4f`, `Vec4d`, `RGBA8`. Not derivable from the array's
+`data_type`: the quantized types (`Fp4`, `Fp8`, `Fp16`, `FpN`) encode a
+`float32` array at reduced precision, the vector types pair a `float32` or
+`float64` array with a `channel` dimension, and `RGBA8` packs a `uint8`
+`channel` dimension into one 32-bit word. See
 [Supported data types](#supported-data-types).
 
 ### `tree_config`
@@ -107,8 +114,7 @@ tree depth is not parameterized.
 
 One of `global` or `chunk_local`: whether each chunk's grid uses the array's
 global index coordinates or is rebased to the chunk's own origin. `global` is
-REQUIRED for [grid coherence](#grid-coherence-across-chunks) and SHOULD be
-used.
+REQUIRED for [grid coherence](#grid-coherence-across-chunks) and SHOULD be used.
 
 ### `stats`
 
@@ -118,40 +124,43 @@ and maximum values; `all` adds average and standard deviation.
 
 ### `lossless`
 
-A boolean indicating whether decoding reproduces the encoded array exactly.
-When `true`, `tolerance` MUST be `0` and `grid_type` MUST NOT be a quantized
-type. When `false`, `tolerance` MUST be greater than `0` or `grid_type` MUST be
-a quantized type.
+A boolean indicating whether decoding reproduces the encoded array exactly. When
+`true`, `tolerance` MUST be `0` and `grid_type` MUST NOT be a quantized type.
+When `false`, `tolerance` MUST be greater than `0` or `grid_type` MUST be a
+quantized type.
 
 ### `tolerance`
 
 A number ≥ 0: the maximum absolute deviation from the background value at which
-the encoder may leave a voxel inactive. `0` permits dropping only voxels
-exactly equal to the background. See
+the encoder may leave a voxel inactive. `0` permits dropping only voxels exactly
+equal to the background. See
 [Sparsity and losslessness](#sparsity-and-losslessness).
 
 ## Supported chunk shapes
 
-The chunk's rank MUST equal the length of
-[`dimension_roles`](#dimension_roles). Each dimension is constrained by its
-role:
+The chunk's rank MUST equal the length of [`dimension_roles`](#dimension_roles).
+Each dimension is constrained by its role:
 
-| role      | chunk extent                                                                                                                        |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `grid`    | Any extent. The buffer holds one grid per index, so the grid count is the product of the chunk extents along all `grid` dimensions. |
-| `z y x`   | Leaf-aligned, and node-aligned where practical: requirements 2 and 3 of [grid coherence](#grid-coherence-across-chunks).            |
-| `channel` | MUST equal the array extent along that dimension (requirement 6).                                                                   |
+- `grid` — any extent. The buffer holds one grid per index, so the grid count is
+  the product of the chunk extents along all `grid` dimensions.
+- `z y x` — leaf-aligned, and node-aligned where practical: requirements 2 and 3
+  of [grid coherence](#grid-coherence-across-chunks). The innermost spatial
+  dimension is the NanoVDB `x` axis.
+- `channel` — MUST be extent 1, 3, or 4 as NanoVDB only supports scalar, Vec3,
+  Vec4, or uint32 RGBA types.
 
-The innermost spatial dimension is the NanoVDB `x` axis. Writing `t` for the
-index along a single `grid` dimension and `c` for the `channel` index:
+Writing `t` for the index along a single `grid` dimension and `c` for the
+`channel` index:
 
-| `dimension_roles`                | chunk shape           | grid value | grid within buffer | NanoVDB coordinate                                      |
-| -------------------------------- | --------------------- | ---------- | ------------------ | ------------------------------------------------------- |
-| `["z","y","x"]`                  | `[nz, ny, nx]`        | scalar     | the only grid      | `[k, j, i]` → `(i,j,k)`                                 |
-| `["z","y","x","channel"]`, `c=1` | `[nz, ny, nx, 1]`     | scalar     | the only grid      | `[k, j, i, 0]` → `(i,j,k)`                              |
-| `["z","y","x","channel"]`, `c=3` | `[nz, ny, nx, 3]`     | `Vec3`     | the only grid      | `[k, j, i, c]` → `(i,j,k)` component `c`                |
-| `["grid","z","y","x"]`           | `[nt, nz, ny, nx]`    | scalar     | grid `t`           | `[t, k, j, i]` → `(i,j,k)` in grid `t`                  |
-| `["grid","z","y","x","channel"]` | `[nt, nz, ny, nx, c]` | `c`-vector | grid `t`           | `[t, k, j, i, c]` → `(i,j,k)` component `c` in grid `t` |
+| `dimension_roles`                     | chunk shape           | grid value       | grid within buffer | NanoVDB coordinate                                      |
+| ------------------------------------- | --------------------- | ---------------- | ------------------ | ------------------------------------------------------- |
+| `["z","y","x"]`                       | `[nz, ny, nx]`        | scalar           | the only grid      | `[k, j, i]` → `(i,j,k)`                                 |
+| `["z","y","x","channel"]`, `c=1`      | `[nz, ny, nx, 1]`     | scalar           | the only grid      | `[k, j, i, 0]` → `(i,j,k)`                              |
+| `["z","y","x","channel"]`, `c=3`      | `[nz, ny, nx, 3]`     | `Vec3`           | the only grid      | `[k, j, i, c]` → `(i,j,k)` component `c`                |
+| `["grid","z","y","x"]`                | `[nt, nz, ny, nx]`    | scalar           | grid `t`           | `[t, k, j, i]` → `(i,j,k)` in grid `t`                  |
+| `["grid","z","y","x","channel"]`, c=1 | `[nt, nz, ny, nx, c]` | scalar           | grid `t`           | `[t, k, j, i, c]` → `(i,j,k)` in grid `t`               |
+| `["grid","z","y","x","channel"]`, c=3 | `[nt, nz, ny, nx, c]` | `Vec3` or `RGBA` | grid `t`           | `[t, k, j, i, c]` → `(i,j,k)` component `c` in grid `t` |
+| `["grid","z","y","x","channel"]`, c=4 | `[nt, nz, ny, nx, c]` | `Vec4` or `RGBA` | grid `t`           | `[t, k, j, i, c]` → `(i,j,k)` component `c` in grid `t` |
 
 Encoders and decoders MUST return an error if the roles are not in the required
 order, if the rank disagrees with `dimension_roles`, if the `channel` extent
@@ -165,13 +174,14 @@ array-to-bytes codec within the
 
 ## Supported data types
 
-Scalar grids take an input with no `channel` dimension, or a `channel`
-dimension of extent `1`:
+Scalar grids take an input with no `channel` dimension, or a `channel` dimension
+of extent `1`:
 
 | Zarr `data_type` | `grid_type`                          | Notes                                         |
 | ---------------- | ------------------------------------ | --------------------------------------------- |
 | `float32`        | `Float`, `Fp4`, `Fp8`, `Fp16`, `FpN` | Quantized types are lossy                     |
 | `float64`        | `Double`                             |                                               |
+| `uint8`          | `UInt8`                              |                                               |
 | `int16`          | `Int16`                              |                                               |
 | `int32`          | `Int32`                              |                                               |
 | `int64`          | `Int64`                              |                                               |
@@ -186,16 +196,24 @@ Vector grids take a `channel` dimension of extent `c`:
 | `float64`        | `3` | `Vec3d`     |
 | `float32`        | `4` | `Vec4f`     |
 | `float64`        | `4` | `Vec4d`     |
+| `uint8`          | `3` | `RGBA8`     |
+| `uint8`          | `4` | `RGBA8`     |
 
 A `channel` extent of `2`, or greater than `4`, MUST be rejected. Such an axis
 SHOULD be given the `grid` role instead, placing each index on its own grid.
 
-Data types not listed above are supported only through promotion:
-implementations MAY promote a narrower data type to a wider `grid_type` (for
-example `uint8` or `int8` to `Int16`), but MUST record the `grid_type` actually
-written and MUST NOT promote across the scalar/vector boundary. Zarr data types
-with no NanoVDB counterpart (complex and variable-length types among them) are
-not supported.
+`RGBA8` is not a vector value type but a single 32-bit word, so it has rules of
+its own. NanoVDB places red in the lowest byte, and the `channel` index gives
+the component: `0` red, `1` green, `2` blue, `3` alpha. With an extent of `3` an
+encoder MUST write an alpha of `255`, and a decoder MUST discard the alpha byte,
+so a three-channel array still round-trips exactly and `lossless: true` remains
+available. The background is the word whose red, green and blue bytes all equal
+`fill_value`, with alpha `255` at an extent of `3` and `fill_value` at an extent
+of `4`.
+
+A `uint8` array is `UInt8` when it has no `channel` dimension and `RGBA8` when
+it has one of extent `3` or `4`; this is why `grid_type` is declared rather than
+derived from `data_type`.
 
 Matrix grids, which would need two `channel` dimensions, and integer vector
 grids (`Vec3i` and similar) are out of scope.
@@ -208,10 +226,9 @@ For vector grids, `fill_value` being a scalar means:
   non-background if _any_ component differs from `fill_value` by more than
   `tolerance`.
 
-> [!NOTE]
-> **Open question for review.** `stats: minmax` is undefined for vector grids,
-> which have no natural total order. Componentwise minima and maxima are the
-> plausible reading; the conservative option is to restrict vector grids to
+> [!NOTE] **Open question for review.** `stats: minmax` is undefined for vector
+> grids, which have no natural total order. Componentwise minima and maxima are
+> the plausible reading; the conservative option is to restrict vector grids to
 > `stats: none` or `bbox`.
 
 ## Format and algorithm
@@ -231,9 +248,9 @@ NanoVDB's grid builders, written verbatim.
 
 #### Grid enumeration
 
-An input whose [`dimension_roles`](#dimension_roles) contain no `grid`
-dimension encodes one grid per chunk. Otherwise the chunk's buffer holds
-`mGridCount` grids, laid out as `nanovdb::mergeGrids` produces them:
+An input whose [`dimension_roles`](#dimension_roles) contain no `grid` dimension
+encodes one grid per chunk. Otherwise the chunk's buffer holds `mGridCount`
+grids, laid out as `nanovdb::mergeGrids` produces them:
 
 - The grid count MUST equal the product of the chunk's extents along its `grid`
   dimensions, and MUST be recorded as `mGridCount` in **every** grid's header,
@@ -244,68 +261,57 @@ dimension encodes one grid per chunk. Otherwise the chunk's buffer holds
 - Grid `n` MUST record `mGridIndex` equal to `n`, where `n` is the C-order
   (row-major, last `grid` dimension varying fastest) ravel of the chunk-local
   indices along the `grid` dimensions.
-- Readers MUST resolve a grid by index, never by `mGridName`, which is
-  unconstrained. Writers MAY set names.
+- Readers MUST resolve a grid by index. Writers MAY set names, via `mGridName`,
+  but it is unconstrained, so readers MUST not rely on them.
 
 ### Grid coherence across chunks
 
 An array using this codec MUST satisfy all of the following. Each is checkable
 from the array metadata and chunk buffers alone.
 
-1. **One index space.** Each chunk's grids MUST express voxel coordinates in
-   the global index space of this codec's input: the `z`, `y`, `x` indices
+1. **One index space.** Each chunk's grids MUST express voxel coordinates in the
+   global index space of this codec's input: the `z`, `y`, `x` indices
    `[k, j, i]` occupy NanoVDB coordinate `(i, j, k)` regardless of which chunk
-   holds them. Grids MUST NOT be rebased to a chunk-local origin. A preceding
-   [`transpose`](../transpose/README.md) composes a constant permutation onto
-   this mapping: the array coordinate is recovered from the NanoVDB coordinate
-   by `order`.
+   holds them. Grids MUST NOT be rebased to a chunk-local origin.
 
 2. **Leaf-aligned chunk grid.** The chunk extent along each of the `z`, `y` and
-   `x` dimensions, and the chunk grid origin in each of them, MUST be an
-   integer multiple of the leaf extent `1 << tree_config[2]` (8 for
-   `[5, 4, 3]`), so that no leaf node straddles a chunk boundary.
+   `x` dimensions, and the chunk grid origin in each of them, MUST be an integer
+   multiple of the leaf extent `1 << tree_config[2]` (8 for `[5, 4, 3]`), so
+   that no leaf node straddles a chunk boundary.
 
 3. **Node-aligned chunk shape (recommended).** The `z`, `y` and `x` chunk
    extents SHOULD additionally be an integer multiple of, or an integer divisor
-   of, the lower internal node extent
-   `1 << (tree_config[1] + tree_config[2])` (128 for `[5, 4, 3]`). A chunk of
-   exactly one node extent is a subtree with a dense top level, traversable
-   without searching the root node's tile table; other shapes satisfying
-   requirement 2 are conformant but require a root-level lookup.
-
-   Requirements 2 and 3 constrain only the three spatial dimensions; a
-   `channel` dimension is governed by requirement 6 and a `grid` dimension by
-   requirement 7. Where a `transpose` precedes this codec the constrained
-   extents are `chunk_shape[order[i]]` for the relevant `i`, since `transpose`
-   permutes extents without changing them.
+   of, the lower internal node extent `1 << (tree_config[1] + tree_config[2])`
+   (128 for `[5, 4, 3]`). A chunk of exactly one node extent is a subtree with a
+   dense top level, traversable without searching the root node's tile table;
+   other shapes satisfying requirement 2 are conformant but require a root-level
+   lookup.
 
 4. **Disjoint coverage.** Each of a chunk's grids MUST contain active voxels
    only within that chunk's spatial bounds, so for every index along the `grid`
-   dimensions the array's active set is the disjoint union of its chunks'
-   active sets.
+   dimensions the array's active set is the disjoint union of its chunks' active
+   sets.
 
-5. **Uniform configuration.** Every grid of every chunk of an array MUST use
-   the same `grid_type`, `tree_config`, `stats`, and background value.
+5. **Uniform configuration.** Every grid of every chunk of an array MUST use the
+   same `grid_type`, `tree_config`, `stats`, and background value.
 
-6. **Whole vectors per chunk.** The chunk extent along a `channel` dimension
-   MUST equal the array extent along it, so that no chunk holds a partial
-   vector.
-
-7. **Grids addressable by index.** A chunk's grid count MUST equal the product
-   of its extents along the `grid` dimensions, and grid `n` of the buffer MUST
-   correspond to the C-order ravel of the chunk-local `grid` indices, as
-   specified in [Grid enumeration](#grid-enumeration).
+6. **Grids addressable by index.** A chunk's grid count MUST equal the product
+   of its extents along the `grid` dimensions see
+   [Grid enumeration](#grid-enumeration).
 
 ### Sparsity and losslessness
 
 Decoding produces the grid's active values composited over the array's
 `fill_value`: every voxel the grid does not represent decodes as `fill_value`.
 
-- With `lossless: true` (`tolerance: 0`), an encoder MUST leave a voxel
-  inactive only if it exactly equals the background; decoding reproduces the
-  input bit-for-bit.
+- With `lossless: true` (`tolerance: 0`), an encoder MUST leave a voxel inactive
+  only if and only if it exactly equals the background so that decoding
+  reproduces the input bit-for-bit.
 - With `lossless: false` and `tolerance: t > 0`, an encoder MAY additionally
-  leave inactive any voxel within `t` of the background.
+  leave inactive any voxel within `t` of the background. Custom algorithms may
+  choose to use a more complex rule than thresholding the data at
+  fill_value+tolerance, and simply write down a tolerance based on empircal
+  upper limit of dropped voxel values after writing in tolerance.
 - The quantized grid types are lossy in the value domain independently of
   `tolerance`.
 
@@ -318,8 +324,8 @@ active are stored at full precision, subject to `grid_type`.
 `array -> array` codec may, and implementations SHOULD reject such a chain when
 the array metadata is parsed:
 
-- [`reshape`](../reshape/README.md) does not preserve dimension identity, so
-  no role describes its output. Composing it with `transpose` does not make it
+- [`reshape`](../reshape/README.md) does not preserve dimension identity, so no
+  role describes its output. Composing it with `transpose` does not make it
   conformant.
 - Value-domain codecs, [`cast_value`](../cast_value/README.md) and
   [`scale_offset`](../scale_offset/README.md) among them, would leave grid
@@ -334,23 +340,34 @@ traverse it directly. Such a reader skips the `array -> array` decode stage, so
 it MUST compose the permutation of any preceding
 [`transpose`](../transpose/README.md) into its own coordinate mapping.
 
-This is most useful for direct GPU rendering applications, and skipping subtrees by value range requires `stats` of `minmax` or `all`;
-encoders targeting such readers SHOULD write one of those rather than `none`.
+This is most useful for direct GPU rendering applications, and skipping subtrees
+by value range requires `stats` of `minmax` or `all`; encoders targeting such
+readers SHOULD write one of those rather than `none`.
 
 ## Examples
 
-`float32`, leaf- and node-aligned 128³ chunks, lossless, with per-node
-min/max:
+`float32`, leaf- and node-aligned 128³ chunks, lossless, with per-node min/max:
 
 ```json
 {
+  "zarr_format": 3,
+  "node_type": "array",
   "shape": [1024, 2048, 2048],
   "data_type": "float32",
-  "fill_value": 0.0,
   "chunk_grid": {
     "name": "regular",
-    "configuration": { "chunk_shape": [128, 128, 128] }
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
   },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "dimension_names": ["z", "y", "x"],
   "codecs": [
     {
       "name": "nanovdb",
@@ -364,7 +381,13 @@ min/max:
         "tolerance": 0.0
       }
     },
-    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+    {
+      "name": "zstd",
+      "configuration": {
+        "level": 3,
+        "checksum": false
+      }
+    }
   ]
 }
 ```
@@ -373,6 +396,24 @@ A segmentation mask, topology only:
 
 ```json
 {
+  "zarr_format": 3,
+  "node_type": "array",
+  "shape": [1024, 2048, 2048],
+  "data_type": "bool",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": false,
+  "dimension_names": ["z", "y", "x"],
   "codecs": [
     {
       "name": "nanovdb",
@@ -394,6 +435,24 @@ Quantized and sparsified with a recorded tolerance:
 
 ```json
 {
+  "zarr_format": 3,
+  "node_type": "array",
+  "shape": [1024, 2048, 2048],
+  "data_type": "float32",
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": {
+      "chunk_shape": [128, 128, 128]
+    }
+  },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "dimension_names": ["z", "y", "x"],
   "codecs": [
     {
       "name": "nanovdb",
@@ -407,7 +466,13 @@ Quantized and sparsified with a recorded tolerance:
         "tolerance": 12.0
       }
     },
-    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+    {
+      "name": "zstd",
+      "configuration": {
+        "level": 3,
+        "checksum": false
+      }
+    }
   ]
 }
 ```
@@ -417,13 +482,24 @@ covers `channel` in full:
 
 ```json
 {
+  "zarr_format": 3,
+  "node_type": "array",
   "shape": [512, 1024, 1024, 3],
   "data_type": "float32",
-  "fill_value": 0.0,
   "chunk_grid": {
     "name": "regular",
-    "configuration": { "chunk_shape": [128, 128, 128, 3] }
+    "configuration": {
+      "chunk_shape": [128, 128, 128, 3]
+    }
   },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "dimension_names": ["z", "y", "x", "c"],
   "codecs": [
     {
       "name": "nanovdb",
@@ -437,7 +513,13 @@ covers `channel` in full:
         "tolerance": 0.0
       }
     },
-    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+    {
+      "name": "zstd",
+      "configuration": {
+        "level": 3,
+        "checksum": false
+      }
+    }
   ]
 }
 ```
@@ -447,14 +529,24 @@ grids per chunk buffer.
 
 ```json
 {
+  "zarr_format": 3,
+  "node_type": "array",
   "shape": [64, 1024, 2048, 2048],
   "data_type": "float32",
-  "fill_value": 0.0,
-  "dimension_names": ["t", "z", "y", "x"],
   "chunk_grid": {
     "name": "regular",
-    "configuration": { "chunk_shape": [4, 128, 128, 128] }
+    "configuration": {
+      "chunk_shape": [4, 128, 128, 128]
+    }
   },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "dimension_names": ["t", "z", "y", "x"],
   "codecs": [
     {
       "name": "nanovdb",
@@ -468,7 +560,13 @@ grids per chunk buffer.
         "tolerance": 0.0
       }
     },
-    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+    {
+      "name": "zstd",
+      "configuration": {
+        "level": 3,
+        "checksum": false
+      }
+    }
   ]
 }
 ```
@@ -477,14 +575,24 @@ The same with a three-component value per voxel, `[T, Z, Y, X, C]`:
 
 ```json
 {
+  "zarr_format": 3,
+  "node_type": "array",
   "shape": [64, 1024, 2048, 2048, 3],
   "data_type": "float32",
-  "fill_value": 0.0,
-  "dimension_names": ["t", "z", "y", "x", "c"],
   "chunk_grid": {
     "name": "regular",
-    "configuration": { "chunk_shape": [4, 128, 128, 128, 3] }
+    "configuration": {
+      "chunk_shape": [4, 128, 128, 128, 3]
+    }
   },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "dimension_names": ["t", "z", "y", "x", "c"],
   "codecs": [
     {
       "name": "nanovdb",
@@ -498,7 +606,13 @@ The same with a three-component value per voxel, `[T, Z, Y, X, C]`:
         "tolerance": 0.0
       }
     },
-    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+    {
+      "name": "zstd",
+      "configuration": {
+        "level": 3,
+        "checksum": false
+      }
+    }
   ]
 }
 ```
@@ -509,16 +623,31 @@ codec's input `[t, z, y, x, c]`. `dimension_names` is in the array's order and
 
 ```json
 {
+  "zarr_format": 3,
+  "node_type": "array",
   "shape": [64, 3, 1024, 2048, 2048],
   "data_type": "float32",
-  "fill_value": 0.0,
-  "dimension_names": ["t", "c", "z", "y", "x"],
   "chunk_grid": {
     "name": "regular",
-    "configuration": { "chunk_shape": [4, 3, 128, 128, 128] }
+    "configuration": {
+      "chunk_shape": [4, 3, 128, 128, 128]
+    }
   },
+  "chunk_key_encoding": {
+    "name": "default",
+    "configuration": {
+      "separator": "/"
+    }
+  },
+  "fill_value": 0.0,
+  "dimension_names": ["t", "c", "z", "y", "x"],
   "codecs": [
-    { "name": "transpose", "configuration": { "order": [0, 2, 3, 4, 1] } },
+    {
+      "name": "transpose",
+      "configuration": {
+        "order": [0, 2, 3, 4, 1]
+      }
+    },
     {
       "name": "nanovdb",
       "configuration": {
@@ -531,7 +660,13 @@ codec's input `[t, z, y, x, c]`. `dimension_names` is in the array's order and
         "tolerance": 0.0
       }
     },
-    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+    {
+      "name": "zstd",
+      "configuration": {
+        "level": 3,
+        "checksum": false
+      }
+    }
   ]
 }
 ```
@@ -554,8 +689,8 @@ expected decoded values and active/inactive topology.
   a buffer written by a newer NanoVDB or holding a value type it does not
   handle. It does not declare its tree configuration; see
   [`tree_config`](#tree_config).
-- Reference implementation: in progress, targeting a Zarr reader that passes
-  the buffer through to a GPU without densifying it.
+- Reference implementation: in progress, targeting a Zarr reader that passes the
+  buffer through to a GPU without densifying it.
 
 ## Change log
 

--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -122,20 +122,6 @@ One of `none`, `bbox`, `minmax`, `all`: the per-node statistics the grid
 carries. `bbox` includes active bounding boxes; `minmax` adds per-node minimum
 and maximum values; `all` adds average and standard deviation.
 
-### `lossless`
-
-A boolean indicating whether decoding reproduces the encoded array exactly. When
-`true`, `tolerance` MUST be `0` and `grid_type` MUST NOT be a quantized type.
-When `false`, `tolerance` MUST be greater than `0` or `grid_type` MUST be a
-quantized type.
-
-### `tolerance`
-
-A number ≥ 0: the maximum absolute deviation from the background value at which
-the encoder may leave a voxel inactive. `0` permits dropping only voxels exactly
-equal to the background. See
-[Sparsity and losslessness](#sparsity-and-losslessness).
-
 ## Supported chunk shapes
 
 The chunk's rank MUST equal the length of [`dimension_roles`](#dimension_roles).
@@ -206,8 +192,8 @@ SHOULD be given the `grid` role instead, placing each index on its own grid.
 its own. NanoVDB places red in the lowest byte, and the `channel` index gives
 the component: `0` red, `1` green, `2` blue, `3` alpha. With an extent of `3` an
 encoder MUST write an alpha of `255`, and a decoder MUST discard the alpha byte,
-so a three-channel array still round-trips exactly and `lossless: true` remains
-available. The background is the word whose red, green and blue bytes all equal
+so a three-channel array still round-trips exactly. The background is the word
+whose red, green and blue bytes all equal
 `fill_value`, with alpha `255` at an extent of `3` and `fill_value` at an extent
 of `4`.
 
@@ -222,9 +208,8 @@ For vector grids, `fill_value` being a scalar means:
 
 - The grid's background value MUST be the vector all of whose components equal
   `fill_value`. A background with unequal components MUST NOT be written.
-- A voxel is active or inactive as a whole. An encoder MUST treat a voxel as
-  non-background if _any_ component differs from `fill_value` by more than
-  `tolerance`.
+- A voxel is active or inactive as a whole. A voxel is active if _any_ of its
+  components differs from `fill_value`.
 
 > [!NOTE] **Open question for review.** `stats: minmax` is undefined for vector
 > grids, which have no natural total order. Componentwise minima and maxima are
@@ -299,24 +284,19 @@ from the array metadata and chunk buffers alone.
    of its extents along the `grid` dimensions see
    [Grid enumeration](#grid-enumeration).
 
-### Sparsity and losslessness
+### Sparsity
 
-Decoding produces the grid's active values composited over the array's
+A voxel is active if and only if its value differs from the array's
+`fill_value`. Decoding produces the grid's active values composited over
 `fill_value`: every voxel the grid does not represent decodes as `fill_value`.
 
-- With `lossless: true` (`tolerance: 0`), an encoder MUST leave a voxel inactive
-  only if and only if it exactly equals the background so that decoding
-  reproduces the input bit-for-bit.
-- With `lossless: false` and `tolerance: t > 0`, an encoder MAY additionally
-  leave inactive any voxel within `t` of the background. Custom algorithms may
-  choose to use a more complex rule than thresholding the data at
-  fill_value+tolerance, and simply write down a tolerance based on empircal
-  upper limit of dropped voxel values after writing in tolerance.
-- The quantized grid types are lossy in the value domain independently of
-  `tolerance`.
+Activity is therefore fully determined by the array and its `fill_value`. An
+encoder has no discretion, two conformant encoders produce the same active set,
+and decoding reproduces the input bit-for-bit for every non-quantized
+`grid_type`. 
 
-`tolerance` is a topology threshold, not a value threshold: voxels that remain
-active are stored at full precision, subject to `grid_type`.
+Choosing which voxels to store is the writer's business, not the codec's: to
+drop a voxel write `fill_value` into it before encoding.
 
 ## Interaction with other codecs
 
@@ -346,7 +326,7 @@ readers SHOULD write one of those rather than `none`.
 
 ## Examples
 
-`float32`, leaf- and node-aligned 128³ chunks, lossless, with per-node min/max:
+`float32`, leaf- and node-aligned 128³ chunks, with per-node min/max:
 
 ```json
 {
@@ -376,9 +356,7 @@ readers SHOULD write one of those rather than `none`.
         "grid_type": "Float",
         "tree_config": [5, 4, 3],
         "index_space": "global",
-        "stats": "minmax",
-        "lossless": true,
-        "tolerance": 0.0
+        "stats": "minmax"
       }
     },
     {
@@ -422,16 +400,14 @@ A segmentation mask, topology only:
         "grid_type": "Mask",
         "tree_config": [5, 4, 3],
         "index_space": "global",
-        "stats": "bbox",
-        "lossless": true,
-        "tolerance": 0.0
+        "stats": "bbox"
       }
     }
   ]
 }
 ```
 
-Quantized and sparsified with a recorded tolerance:
+Quantized to 16 bits per voxel:
 
 ```json
 {
@@ -461,9 +437,7 @@ Quantized and sparsified with a recorded tolerance:
         "grid_type": "Fp16",
         "tree_config": [5, 4, 3],
         "index_space": "global",
-        "stats": "all",
-        "lossless": false,
-        "tolerance": 12.0
+        "stats": "all"
       }
     },
     {
@@ -508,9 +482,7 @@ covers `channel` in full:
         "grid_type": "Vec3f",
         "tree_config": [5, 4, 3],
         "index_space": "global",
-        "stats": "bbox",
-        "lossless": true,
-        "tolerance": 0.0
+        "stats": "bbox"
       }
     },
     {
@@ -555,9 +527,7 @@ grids per chunk buffer.
         "grid_type": "Float",
         "tree_config": [5, 4, 3],
         "index_space": "global",
-        "stats": "minmax",
-        "lossless": true,
-        "tolerance": 0.0
+        "stats": "minmax"
       }
     },
     {
@@ -601,9 +571,7 @@ The same with a three-component value per voxel, `[T, Z, Y, X, C]`:
         "grid_type": "Vec3f",
         "tree_config": [5, 4, 3],
         "index_space": "global",
-        "stats": "bbox",
-        "lossless": true,
-        "tolerance": 0.0
+        "stats": "bbox"
       }
     },
     {
@@ -655,9 +623,7 @@ codec's input `[t, z, y, x, c]`. `dimension_names` is in the array's order and
         "grid_type": "Vec3f",
         "tree_config": [5, 4, 3],
         "index_space": "global",
-        "stats": "bbox",
-        "lossless": true,
-        "tolerance": 0.0
+        "stats": "bbox"
       }
     },
     {
@@ -671,12 +637,6 @@ codec's input `[t, z, y, x, c]`. `dimension_names` is in the array's order and
 }
 ```
 
-## Example data
-
-TBD. Fixtures are planned alongside the reference implementation: a small
-`float32` volume and a `Mask` volume, each with a `fixtures.json` recording the
-expected decoded values and active/inactive topology.
-
 ## Interoperability and compatibility
 
 - The buffer is a plain NanoVDB grid, readable by NanoVDB independently of Zarr
@@ -689,8 +649,11 @@ expected decoded values and active/inactive topology.
   a buffer written by a newer NanoVDB or holding a value type it does not
   handle. It does not declare its tree configuration; see
   [`tree_config`](#tree_config).
-- Reference implementation: in progress, targeting a Zarr reader that passes the
-  buffer through to a GPU without densifying it.
+
+## Reference implementation
+
+-
+- Experimental neuroglancer branch:
 
 ## Change log
 

--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -46,10 +46,26 @@ component dimension. See [Supported data types](#supported-data-types).
 
 ### `tree_config`
 
-The node branching factors of the tree, written as the `Log2Dim` values from
-root side to leaf, hyphen-separated. MUST be `5-4-3` (OpenVDB's default: 8³
-leaves, 128³ lower and 4096³ upper internal nodes); declared explicitly so that
-other configurations can be registered later without ambiguity.
+An array of the tree's node branching factors, as the `Log2Dim` of each level
+from the root side to the leaf. MUST be `[5, 4, 3]`, giving 8³ leaves, 128³
+lower internal nodes and 4096³ upper internal nodes. Every extent the
+[grid coherence](#grid-coherence-across-chunks) requirements refer to derives
+from this array: the leaf extent is `1 << tree_config[2]` and the lower
+internal node extent is `1 << (tree_config[1] + tree_config[2])`.
+
+`[5, 4, 3]` is the only registered configuration, for two reasons beyond its
+being OpenVDB's default:
+
+- It is the only one the official released NanoVDB implementation reads or
+  writes.
+- A reader cannot recover the configuration from the buffer.
+
+The field is therefore declared explicitly rather than assumed, so that a
+reader can reject what it does not implement instead of misreading it, and so
+that another configuration can be registered later without ambiguity. Any
+future value MUST also have exactly three entries: NanoVDB's tree depth is not
+parameterized, and the [grid coherence](#grid-coherence-across-chunks)
+requirements assume the three levels above.
 
 ### `index_space`
 
@@ -123,7 +139,7 @@ Scalar grids take a rank-3 chunk:
 | `int32`          | `Int32`                              |                                               |
 | `int64`          | `Int64`                              |                                               |
 | `uint32`         | `UInt32`                             |                                               |
-| `bool`           | `Mask`                               | Topology only; the value *is* the active mask |
+| `bool`           | `Mask`                               | Topology only; the value _is_ the active mask |
 
 Vector grids take a rank-4 chunk whose innermost dimension is the component
 dimension, with extent `c`:
@@ -154,7 +170,7 @@ For vector grids, two consequences of Zarr's `fill_value` being a scalar:
   `fill_value`; a background with unequal components cannot be expressed in the
   array metadata and MUST NOT be written.
 - A voxel is active or inactive as a whole. An encoder MUST treat a voxel as
-  non-background if *any* component differs from `fill_value` by more than
+  non-background if _any_ component differs from `fill_value` by more than
   `tolerance`.
 
 > [!NOTE]
@@ -197,12 +213,13 @@ chunk buffers alone.
 
 2. **Leaf-aligned chunk grid.** Every spatial chunk dimension, and the chunk
    grid origin in each spatial dimension, MUST be an integer multiple of the
-   leaf extent implied by `tree_config` (8 for `5-4-3`), so that no leaf node
+   leaf extent `1 << tree_config[2]` (8 for `[5, 4, 3]`), so that no leaf node
    straddles a chunk boundary.
 
 3. **Node-aligned chunk shape (recommended).** Spatial chunk dimensions SHOULD
    additionally be an integer multiple of, or an integer divisor of, the lower
-   internal node extent (128 for `5-4-3`). A chunk that is an exact node extent
+   internal node extent `1 << (tree_config[1] + tree_config[2])` (128 for
+   `[5, 4, 3]`). A chunk that is an exact node extent
    is a clean subtree with a dense top level, addressable without searching the
    root node's tile table; other shapes satisfying requirement 2 remain
    conformant at the cost of a root-level lookup per traversal. The component
@@ -251,7 +268,7 @@ reject such a chain when the array metadata is parsed:
    ([`transpose`](../transpose/README.md), [`reshape`](../reshape/README.md))
    break requirement 1 of [grid coherence](#grid-coherence-across-chunks),
    which ties NanoVDB coordinates to array index coordinates.
-2. `array -> array` codecs decode *after* the `array -> bytes` codec. A reader
+2. `array -> array` codecs decode _after_ the `array -> bytes` codec. A reader
    taking the pass-through path below never materializes a dense array for them
    to operate on, so permitting them would forfeit that optimization for
    exactly the arrays this codec serves. This excludes even value-domain codecs
@@ -293,7 +310,7 @@ against a background of `0.0`, with per-node min/max statistics:
       "name": "nanovdb",
       "configuration": {
         "grid_type": "Float",
-        "tree_config": "5-4-3",
+        "tree_config": [5, 4, 3],
         "index_space": "global",
         "stats": "minmax",
         "lossless": true,
@@ -314,7 +331,7 @@ A segmentation mask, storing topology only:
       "name": "nanovdb",
       "configuration": {
         "grid_type": "Mask",
-        "tree_config": "5-4-3",
+        "tree_config": [5, 4, 3],
         "index_space": "global",
         "stats": "bbox",
         "lossless": true,
@@ -334,7 +351,7 @@ Thresholded fluorescence, quantized and sparsified with a recorded tolerance:
       "name": "nanovdb",
       "configuration": {
         "grid_type": "Fp16",
-        "tree_config": "5-4-3",
+        "tree_config": [5, 4, 3],
         "index_space": "global",
         "stats": "all",
         "lossless": false,
@@ -364,7 +381,7 @@ full by the chunk shape, so every chunk holds whole vectors:
       "name": "nanovdb",
       "configuration": {
         "grid_type": "Vec3f",
-        "tree_config": "5-4-3",
+        "tree_config": [5, 4, 3],
         "index_space": "global",
         "stats": "bbox",
         "lossless": true,
@@ -388,7 +405,7 @@ expected decoded values and active/inactive topology.
   built on it, independently of Zarr.
 - Grids can be produced from OpenVDB grids with `nanovdb::createNanoGrid`, and
   from dense arrays with NanoVDB's build tools. OpenVDB's own `.vdb`
-  serialization is *not* interchangeable with a NanoVDB buffer and must be
+  serialization is _not_ interchangeable with a NanoVDB buffer and must be
   converted.
 - NanoVDB buffers are versioned and self-describing, so a reader can detect a
   buffer written by a newer NanoVDB than it supports and fail cleanly.

--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -1,0 +1,460 @@
+# nanovdb codec
+
+Defines an `array -> bytes` codec that encodes an array chunk as a
+[NanoVDB](https://www.openvdb.org/documentation/doxygen/NanoVDB_MainPage.html)
+grid buffer.
+
+NanoVDB is the linearized, pointer-free serialization of an
+[OpenVDB](https://www.openvdb.org/) tree: a fixed-depth spatial hierarchy in
+which regions holding a single repeated value are stored once as a tile rather
+than as voxels. For volumes that are mostly background — segmentation masks,
+level sets, sparse labels, distance fields, thresholded fluorescence, sparse
+vector fields such as velocity or displacement — this is both a large size
+reduction and a spatial index that a reader can traverse directly.
+
+This codec is intentionally minimal. It fixes the relationship between an array
+chunk and a NanoVDB grid, and — critically — constrains that relationship so
+that the grids of every chunk in an array are **mutually coherent**: they share
+one index space and one node lattice, so the chunks tile a single logical VDB
+rather than being an unrelated collection of small ones. See
+[Grid coherence across chunks](#grid-coherence-across-chunks).
+
+> This document is a proposed extension. It is licensed under the
+> [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
+
+> [!NOTE]
+> **Status: draft.** This is an early proposal opened to solicit feedback. The
+> reference implementation is in progress; see
+> [Interoperability and compatibility](#interoperability-and-compatibility).
+
+## Codec name
+
+The value of the `name` member in the codec object MUST be `nanovdb`.
+
+## Configuration parameters
+
+The `configuration` object is REQUIRED and records the encoding parameters used
+to produce the buffer.
+
+The configuration is a **closed set**: implementations MUST NOT emit members
+other than those below, and a store is non-conformant if `configuration`
+contains unrecognized members. Encoders SHOULD write every member explicitly
+rather than relying on defaults, so the metadata is the definitive record of how
+chunks were encoded.
+
+A NanoVDB buffer is self-describing, so decoders MUST derive grid geometry, grid
+type, and tree configuration from the buffer itself and MUST NOT rely on these
+members to parse it. Decoders MUST, however, verify that what the buffer
+declares is consistent with both the array metadata and this configuration, and
+MUST return an error on mismatch.
+
+**Always present**:
+
+- **`grid_type`** (string): the NanoVDB `GridType` of the encoded grid, as one
+  of `Float`, `Double`, `Int16`, `Int32`, `Int64`, `UInt32`, `Mask`, `Fp4`,
+  `Fp8`, `Fp16`, `FpN`, `Vec3f`, `Vec3d`, `Vec4f`, `Vec4d`. This is not
+  redundant with the array's `data_type`: the quantized types (`Fp4`, `Fp8`,
+  `Fp16`, `FpN`) encode a `float32` array in fewer bits per voxel, and the
+  vector types pair a `float32` or `float64` array with a component dimension.
+  See [Supported data types](#supported-data-types).
+- **`tree_config`** (string): the node branching factors of the tree, written as
+  the `Log2Dim` values from root side to leaf, hyphen-separated. MUST be
+  `5-4-3` (OpenVDB's default: 8³ leaves, 128³ lower internal nodes, 4096³ upper
+  internal nodes). Declared explicitly so that other configurations can be
+  registered later without ambiguity.
+- **`index_space`** (string, one of `global`, `chunk_local`): whether each
+  chunk's grid is expressed in the array's global index coordinates or rebased
+  to the chunk's own origin. `global` is REQUIRED for coherence and SHOULD be
+  used; see [Grid coherence across chunks](#grid-coherence-across-chunks).
+- **`stats`** (string, one of `none`, `bbox`, `minmax`, `all`): which per-node
+  statistics the grid carries. `bbox` includes active bounding boxes; `minmax`
+  adds per-node minimum and maximum values; `all` adds average and standard
+  deviation. Readers that perform empty-space skipping or range estimation
+  depend on `minmax` or `all`; see
+  [Reader pass-through](#reader-pass-through-non-normative).
+- **`lossless`** (boolean): whether decoding reproduces the encoded array
+  exactly. When `true`, `tolerance` MUST be `0` and `grid_type` MUST NOT be one
+  of the quantized types. When `false`, `tolerance` MUST be greater than `0` or
+  `grid_type` MUST be a quantized type.
+- **`tolerance`** (number, ≥ 0): the maximum absolute deviation from the
+  background value at which the encoder may leave a voxel inactive. `0` means
+  only voxels exactly equal to the background may be dropped. See
+  [Sparsity and losslessness](#sparsity-and-losslessness).
+
+## Encoded representation
+
+The encoded chunk is a single NanoVDB grid buffer: the in-memory layout produced
+by NanoVDB's grid builders, written verbatim.
+
+- The buffer MUST contain exactly **one** grid.
+- The buffer MUST be little-endian.
+- The buffer MUST begin with a valid NanoVDB grid magic number and version
+  header. The magic numbers, version encoding, and structure layouts are defined
+  normatively by
+  [`nanovdb/NanoVDB.h`](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/nanovdb/nanovdb/NanoVDB.h)
+  in the OpenVDB repository; this document does not restate them.
+- The buffer MUST NOT be wrapped in the `nanovdb::io` file container. That
+  container adds file-level headers and its own optional compression, both of
+  which duplicate responsibilities that belong to the Zarr chunk key and to
+  `bytes -> bytes` codecs respectively.
+- The grid's **background value** MUST equal the array's `fill_value`. This is
+  what makes inactive voxels decode correctly, and makes the meaning of
+  "inactive" identical across every chunk of the array.
+
+
+## Array shape contract
+
+The chunk MUST have exactly three spatial dimensions, optionally followed by a
+single **component dimension** for vector-valued grids. Spatial dimensions map
+to NanoVDB coordinates in C order, so that the innermost spatial dimension is
+the NanoVDB `x` axis:
+
+| chunk shape       | grid value  | NanoVDB coordinate of array index      |
+| ----------------- | ----------- | -------------------------------------- |
+| `[nz, ny, nx]`    | scalar      | `[k, j, i]` → `(i, j, k)`              |
+| `[nz, ny, nx, c]` | `c`-vector  | `[k, j, i, c]` → `(i, j, k)` comp. `c` |
+
+The two forms are disambiguated by rank alone: a rank-3 chunk is scalar-valued,
+a rank-4 chunk is vector-valued. The component extent `c` MUST be `3` or `4`,
+matching the vector `grid_type` (see
+[Supported data types](#supported-data-types)).
+
+The component dimension MUST be the **innermost** (unit-stride) dimension. This
+is not an arbitrary choice: NanoVDB stores a vector-valued leaf as an array of
+vectors, with a voxel's components contiguous, so an innermost component
+dimension makes the array's memory layout and the grid's identical.
+
+Encoders and decoders MUST return an error if the chunk is not one of these two
+forms, if `c` is neither `3` nor `4`, if `c` disagrees with the component count
+implied by `grid_type`, or if the grid's index bounding box is inconsistent with
+the chunk's position and spatial shape.
+
+Because no `array -> array` codec may precede this one (see
+[Interaction with other codecs](#interaction-with-other-codecs)), the array must
+already be laid out in one of these two forms — the layout cannot be produced by
+a preceding `transpose` or `reshape`. Arrays carrying a time axis, or more
+channels than a vector grid can hold, SHOULD place those on separate arrays so
+that each spatial volume is encoded as its own coherent grid.
+
+These rules apply to the inner chunk shape when this codec is used as the
+array-to-bytes codec within the [`sharding_indexed`](../sharding_indexed/README.md)
+codec.
+
+## Grid coherence across chunks
+
+A NanoVDB grid is normally a *global* structure with its own index space and node
+lattice. Splitting a volume into Zarr chunks and encoding each independently
+would ordinarily destroy that: each chunk would carry an unrelated grid with its
+own origin, its own alignment, and potentially its own tree shape. Readers would
+then have to treat each chunk as an opaque volume rather than as a piece of one
+hierarchy, and no per-chunk grid could be traversed without first resolving
+where it sits.
+
+The following requirements remove that problem at the format level. An array
+using this codec MUST satisfy all of them, and a validator can check every one
+of them from the array metadata plus the chunk buffers alone.
+
+1. **One index space.** When `index_space` is `global`, each chunk's grid MUST
+   express voxel coordinates in the array's global index space — that is, a
+   voxel at array index `[k, j, i]` occupies NanoVDB coordinate `(i, j, k)`,
+   regardless of which chunk holds it. Grids MUST NOT be rebased to a
+   chunk-local origin. A reader can therefore compose the chunks of a region by
+   union, with no coordinate arithmetic, and a writer can produce them by
+   splitting one global grid.
+
+2. **Leaf-aligned chunk grid.** Every **spatial** chunk dimension MUST be an
+   integer multiple of the leaf extent implied by `tree_config` (8 for `5-4-3`),
+   and the array's chunk grid origin MUST be a multiple of that extent in each
+   spatial dimension. No leaf node may straddle a chunk boundary, so every leaf
+   belongs to exactly one chunk.
+
+3. **Node-aligned chunk shape (recommended).** Spatial chunk dimensions SHOULD
+   additionally be an integer multiple of, or an integer divisor of, the lower
+   internal node extent (128 for `5-4-3`). A chunk that is an exact node extent
+   is a clean subtree with a **dense** top level, which lets a reader address
+   the top level by direct indexing instead of searching the root node's tile
+   table. Chunk shapes that satisfy requirement 2 but not this one remain
+   conformant, at the cost of a root-level lookup per traversal.
+
+   The component dimension of a vector-valued array is exempt from requirements
+   2 and 3, and is instead governed by requirement 6.
+
+4. **Disjoint coverage.** A chunk's grid MUST contain active voxels only within
+   that chunk's bounds. Combined with requirement 1, the active set of the array
+   is exactly the disjoint union of the active sets of its chunks, and no voxel
+   is represented twice.
+
+5. **Uniform configuration.** Every chunk of an array MUST use the same
+   `grid_type`, `tree_config`, `stats`, and background value. A reader may
+   therefore specialize its traversal — including compiling a shader — once per
+   array rather than once per chunk.
+
+6. **Whole vectors per chunk.** For a vector-valued array, the chunk extent
+   along the component dimension MUST equal the array extent along it, so that
+   no chunk holds a partial vector. A voxel's components are therefore always
+   resolvable from a single chunk, and a grid never has to be assembled across
+   chunk boundaries to read one value.
+
+Requirement 3 is the only one stated as a recommendation, because the tradeoff is
+a reader-side cost rather than a correctness problem. The remaining five are
+what allow the chunks of an array to be treated as one logical grid, and a
+reader MAY rely on them without inspecting every chunk.
+
+## Supported data types
+
+Scalar grids take a rank-3 chunk:
+
+| Zarr `data_type` | `grid_type`                          | Notes                                         |
+| ---------------- | ------------------------------------ | --------------------------------------------- |
+| `float32`        | `Float`, `Fp4`, `Fp8`, `Fp16`, `FpN` | Quantized types are lossy                     |
+| `float64`        | `Double`                             |                                               |
+| `int16`          | `Int16`                              |                                               |
+| `int32`          | `Int32`                              |                                               |
+| `int64`          | `Int64`                              |                                               |
+| `uint32`         | `UInt32`                             |                                               |
+| `bool`           | `Mask`                               | Topology only; the value *is* the active mask |
+
+Vector grids take a rank-4 chunk whose innermost dimension is the component
+dimension, with extent `c` as given below:
+
+| Zarr `data_type` | `c` | `grid_type` |
+| ---------------- | --- | ----------- |
+| `float32`        | `3` | `Vec3f`     |
+| `float64`        | `3` | `Vec3d`     |
+| `float32`        | `4` | `Vec4f`     |
+| `float64`        | `4` | `Vec4d`     |
+
+This is the natural mapping for an array shaped `[Z, Y, X, C]` with `C = 3` or
+`C = 4`: the component dimension is already innermost, so the array's layout and
+the grid's are identical and no rearrangement is needed. See
+[Array shape contract](#array-shape-contract).
+
+Two consequences of Zarr's `fill_value` being a scalar:
+
+- The grid's background value MUST be the vector all of whose components equal
+  `fill_value`. A vector background with unequal components cannot be expressed
+  in the array metadata and MUST NOT be written.
+- A voxel is active or inactive as a whole; individual components cannot be. An
+  encoder MUST treat a voxel as non-background if *any* component differs from
+  `fill_value` by more than `tolerance`.
+
+> [!NOTE]
+> **Open question for review.** For vector grid types, the semantics of
+> `stats: minmax` are not obviously well defined, since vectors have no natural
+> total order. Componentwise minima and maxima are the plausible reading, but
+> this proposal does not yet fix it, and readers that skip subtrees by value
+> range should not assume a scalar ordering. Feedback welcome; the conservative
+> option is to restrict vector grids to `stats: none` or `stats: bbox`.
+
+Other data types are not supported. NanoVDB's integer vector and matrix grid
+types are candidates for a future revision, pending confirmation of which are
+available across the NanoVDB versions this codec targets.
+
+Implementations MAY support narrower types through promotion (for example
+`uint8` or `int8` to `Int16`), but MUST record the `grid_type` actually written.
+
+## Sparsity and losslessness
+
+Decoding produces the grid's active values composited over the array's
+`fill_value`: every voxel the grid does not represent decodes as `fill_value`.
+
+Whether that round-trips exactly depends on the encoder:
+
+- With `lossless: true` and `tolerance: 0`, an encoder MUST leave a voxel
+  inactive only if its value is exactly equal to the background. Decoding then
+  reproduces the input array bit-for-bit.
+- With `lossless: false` and `tolerance: t > 0`, an encoder MAY additionally
+  leave inactive any voxel within `t` of the background. This is the case that
+  makes the codec useful on noisy data, where a true background is rare but a
+  near-background is common — and it is a deliberate, recorded choice rather
+  than an artifact of the encoder.
+- The quantized grid types are lossy independently of `tolerance`, in the value
+  domain rather than the topology domain.
+
+Note that `tolerance` is a *topology* threshold, not a value threshold: voxels
+that remain active are stored at full precision (subject to `grid_type`).
+Consumers that need a defensible relationship between the stored volume and the
+original measurement should record how `tolerance` was chosen alongside the
+array.
+
+## Interaction with other codecs
+
+**No `array -> array` codec may precede this codec.** There are two independent
+reasons, and the second applies even to codecs that leave the index space
+untouched:
+
+1. A codec that permutes or reshapes dimensions — [`transpose`](../transpose/README.md)
+   or [`reshape`](../reshape/README.md) — breaks requirement 1 of
+   [Grid coherence](#grid-coherence-across-chunks), which fixes NanoVDB
+   coordinates to array index coordinates.
+2. `array -> array` codecs are applied in reverse on read, *after* the
+   `array -> bytes` codec has been decoded. A reader that takes the pass-through
+   path described below never materializes a dense array, so there is nothing
+   for such a codec to operate on. Permitting them would make the pass-through
+   optimization unavailable for the very arrays this codec exists to serve.
+
+Implementations SHOULD reject such a codec chain when the array metadata is
+parsed, rather than at decode time. The practical consequence is that the array
+must natively be laid out as `[Z, Y, X]` or `[Z, Y, X, C]`; this codec
+deliberately does not offer a way to rearrange it.
+
+Value-domain codecs such as [`cast_value`](../cast_value/README.md) and
+[`scale_offset`](../scale_offset/README.md) are `array -> array` codecs and are
+therefore also excluded, notwithstanding that they preserve the index space.
+Where their effect is wanted, it belongs in how the array was written — noting
+in any case that they change what the background value is, and that requirement
+5 applies to the background as this codec sees it.
+
+`bytes -> bytes` codecs compose freely and are the right place for general
+compression and checksums.
+
+## Reader pass-through (non-normative)
+
+A conventional Zarr reader will decode a chunk to a dense array, which discards
+the size advantage as soon as the chunk is in memory. Because the encoded buffer
+is already a spatial index, a reader MAY instead keep the buffer and resolve
+voxels by traversing it — the buffer is pointer-free and position-independent,
+so it can be handed to a GPU as-is and traversed in a shader.
+
+The coherence requirements above are what make this safe to do without
+inspecting the whole array: a reader can specialize its traversal once
+(requirement 5), address chunks by index without coordinate arithmetic
+(requirement 1), assume no leaf spans a boundary (requirement 2), and skip the
+root-level search entirely when requirement 3 holds.
+
+Readers doing this benefit from `stats` being `minmax` or `all`, which lets them
+skip whole subtrees whose value range falls outside the range currently of
+interest, and estimate a display range without sampling. Encoders targeting such
+readers SHOULD therefore write `minmax` or `all` rather than `none`.
+
+## Examples
+
+A `float32` volume stored in leaf- and node-aligned 128³ chunks, losslessly
+sparsified against a background of `0.0`, with per-node minimum and maximum
+statistics:
+
+```json
+{
+  "shape": [1024, 2048, 2048],
+  "data_type": "float32",
+  "fill_value": 0.0,
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": { "chunk_shape": [128, 128, 128] }
+  },
+  "codecs": [
+    {
+      "name": "nanovdb",
+      "configuration": {
+        "grid_type": "Float",
+        "tree_config": "5-4-3",
+        "index_space": "global",
+        "stats": "minmax",
+        "lossless": true,
+        "tolerance": 0.0
+      }
+    },
+    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+  ]
+}
+```
+
+A segmentation mask, where only topology is stored:
+
+```json
+{
+  "codecs": [
+    {
+      "name": "nanovdb",
+      "configuration": {
+        "grid_type": "Mask",
+        "tree_config": "5-4-3",
+        "index_space": "global",
+        "stats": "bbox",
+        "lossless": true,
+        "tolerance": 0.0
+      }
+    }
+  ]
+}
+```
+
+Thresholded fluorescence, quantized and sparsified with a recorded tolerance:
+
+```json
+{
+  "codecs": [
+    {
+      "name": "nanovdb",
+      "configuration": {
+        "grid_type": "Fp16",
+        "tree_config": "5-4-3",
+        "index_space": "global",
+        "stats": "all",
+        "lossless": false,
+        "tolerance": 12.0
+      }
+    },
+    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+  ]
+}
+```
+
+A sparse `float32` displacement field shaped `[Z, Y, X, C]` with `C = 3`,
+encoded as a `Vec3f` grid. Note that the component dimension is innermost and
+that the chunk shape covers it in full, so every chunk holds whole vectors:
+
+```json
+{
+  "shape": [512, 1024, 1024, 3],
+  "data_type": "float32",
+  "fill_value": 0.0,
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": { "chunk_shape": [128, 128, 128, 3] }
+  },
+  "codecs": [
+    {
+      "name": "nanovdb",
+      "configuration": {
+        "grid_type": "Vec3f",
+        "tree_config": "5-4-3",
+        "index_space": "global",
+        "stats": "bbox",
+        "lossless": true,
+        "tolerance": 0.0
+      }
+    },
+    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+  ]
+}
+```
+
+## Example data
+
+TBD. Fixtures are planned alongside the reference implementation: a small
+`float32` volume and a `Mask` volume, each with a `fixtures.json` recording the
+expected decoded values and the active/inactive topology.
+
+## Interoperability and compatibility
+
+- The encoded buffer is a plain NanoVDB grid, so it can be read by NanoVDB
+  itself and by any tool built on it, independently of Zarr.
+- Grids can be produced from OpenVDB grids with `nanovdb::createNanoGrid`, and
+  from dense arrays with NanoVDB's build tools. Note that OpenVDB's own `.vdb`
+  serialization is *not* interchangeable with a NanoVDB buffer: it is a
+  node-graph format with its own per-node compression, and must be converted.
+- Because NanoVDB buffers are versioned and self-describing, a reader can detect
+  a buffer written by a newer NanoVDB than it supports and fail cleanly.
+- Reference implementation: in progress, targeting a Zarr reader that passes the
+  buffer through to a GPU without densifying it. Not yet available; this
+  proposal is opened to solicit feedback on the coherence requirements before
+  the implementation is finalized.
+
+## Change log
+
+No changes yet.
+
+## Current maintainers
+
+- TBD

--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -5,26 +5,20 @@ Defines an `array -> bytes` codec that encodes an array chunk as a
 grid buffer.
 
 NanoVDB is the linearized, pointer-free serialization of an
-[OpenVDB](https://www.openvdb.org/) tree: a fixed-depth spatial hierarchy in
-which regions holding a single repeated value are stored once as a tile rather
-than as voxels. For volumes that are mostly background — segmentation masks,
-level sets, sparse labels, distance fields, thresholded fluorescence, sparse
-vector fields such as velocity or displacement — this is both a large size
-reduction and a spatial index that a reader can traverse directly.
-
-This codec is intentionally minimal. It fixes the relationship between an array
-chunk and a NanoVDB grid, and — critically — constrains that relationship so
-that the grids of every chunk in an array are **mutually coherent**: they share
-one index space and one node lattice, so the chunks tile a single logical VDB
-rather than being an unrelated collection of small ones. See
-[Grid coherence across chunks](#grid-coherence-across-chunks).
+[OpenVDB](https://www.openvdb.org/) tree, in which regions holding a single
+repeated value are stored once as a tile rather than as voxels. For volumes
+that are mostly background (masks, sparse labels, level sets, distance fields,
+sparse vector fields), the buffer is both a compact encoding and a spatial
+index that a reader can traverse directly. This codec constrains how each
+chunk maps to a grid so that the grids of all chunks share one index space and
+node lattice; see [Grid coherence across chunks](#grid-coherence-across-chunks).
 
 > This document is a proposed extension. It is licensed under the
 > [Creative Commons Attribution 3.0 Unported License](https://creativecommons.org/licenses/by/3.0/).
 
 > [!NOTE]
-> **Status: draft.** This is an early proposal opened to solicit feedback. The
-> reference implementation is in progress; see
+> **Status: draft**, opened to solicit feedback. The reference implementation
+> is in progress; see
 > [Interoperability and compatibility](#interoperability-and-compatibility).
 
 ## Codec name
@@ -33,172 +27,89 @@ The value of the `name` member in the codec object MUST be `nanovdb`.
 
 ## Configuration parameters
 
-The `configuration` object is REQUIRED and records the encoding parameters used
-to produce the buffer.
+The `configuration` object is REQUIRED and all of its members are required. It
+is a closed set: implementations MUST NOT emit members other than those below.
 
-The configuration is a **closed set**: implementations MUST NOT emit members
-other than those below, and a store is non-conformant if `configuration`
-contains unrecognized members. Encoders SHOULD write every member explicitly
-rather than relying on defaults, so the metadata is the definitive record of how
-chunks were encoded.
-
-A NanoVDB buffer is self-describing, so decoders MUST derive grid geometry, grid
-type, and tree configuration from the buffer itself and MUST NOT rely on these
-members to parse it. Decoders MUST, however, verify that what the buffer
-declares is consistent with both the array metadata and this configuration, and
+Because a NanoVDB buffer is self-describing, decoders MUST derive grid
+geometry, grid type, and tree configuration from the buffer itself; MUST verify
+that they are consistent with the array metadata and this configuration; and
 MUST return an error on mismatch.
 
-**Always present**:
+### `grid_type`
 
-- **`grid_type`** (string): the NanoVDB `GridType` of the encoded grid, as one
-  of `Float`, `Double`, `Int16`, `Int32`, `Int64`, `UInt32`, `Mask`, `Fp4`,
-  `Fp8`, `Fp16`, `FpN`, `Vec3f`, `Vec3d`, `Vec4f`, `Vec4d`. This is not
-  redundant with the array's `data_type`: the quantized types (`Fp4`, `Fp8`,
-  `Fp16`, `FpN`) encode a `float32` array in fewer bits per voxel, and the
-  vector types pair a `float32` or `float64` array with a component dimension.
-  See [Supported data types](#supported-data-types).
-- **`tree_config`** (string): the node branching factors of the tree, written as
-  the `Log2Dim` values from root side to leaf, hyphen-separated. MUST be
-  `5-4-3` (OpenVDB's default: 8³ leaves, 128³ lower internal nodes, 4096³ upper
-  internal nodes). Declared explicitly so that other configurations can be
-  registered later without ambiguity.
-- **`index_space`** (string, one of `global`, `chunk_local`): whether each
-  chunk's grid is expressed in the array's global index coordinates or rebased
-  to the chunk's own origin. `global` is REQUIRED for coherence and SHOULD be
-  used; see [Grid coherence across chunks](#grid-coherence-across-chunks).
-- **`stats`** (string, one of `none`, `bbox`, `minmax`, `all`): which per-node
-  statistics the grid carries. `bbox` includes active bounding boxes; `minmax`
-  adds per-node minimum and maximum values; `all` adds average and standard
-  deviation. Readers that perform empty-space skipping or range estimation
-  depend on `minmax` or `all`; see
-  [Reader pass-through](#reader-pass-through-non-normative).
-- **`lossless`** (boolean): whether decoding reproduces the encoded array
-  exactly. When `true`, `tolerance` MUST be `0` and `grid_type` MUST NOT be one
-  of the quantized types. When `false`, `tolerance` MUST be greater than `0` or
-  `grid_type` MUST be a quantized type.
-- **`tolerance`** (number, ≥ 0): the maximum absolute deviation from the
-  background value at which the encoder may leave a voxel inactive. `0` means
-  only voxels exactly equal to the background may be dropped. See
-  [Sparsity and losslessness](#sparsity-and-losslessness).
+The NanoVDB `GridType` of the encoded grid: one of `Float`, `Double`, `Int16`,
+`Int32`, `Int64`, `UInt32`, `Mask`, `Fp4`, `Fp8`, `Fp16`, `FpN`, `Vec3f`,
+`Vec3d`, `Vec4f`, `Vec4d`. Not redundant with the array's `data_type`: the
+quantized types (`Fp4`, `Fp8`, `Fp16`, `FpN`) encode a `float32` array in fewer
+bits per voxel, and the vector types pair a `float32` or `float64` array with a
+component dimension. See [Supported data types](#supported-data-types).
 
-## Encoded representation
+### `tree_config`
 
-The encoded chunk is a single NanoVDB grid buffer: the in-memory layout produced
-by NanoVDB's grid builders, written verbatim.
+The node branching factors of the tree, written as the `Log2Dim` values from
+root side to leaf, hyphen-separated. MUST be `5-4-3` (OpenVDB's default: 8³
+leaves, 128³ lower and 4096³ upper internal nodes); declared explicitly so that
+other configurations can be registered later without ambiguity.
 
-- The buffer MUST contain exactly **one** grid.
-- The buffer MUST be little-endian.
-- The buffer MUST begin with a valid NanoVDB grid magic number and version
-  header. The magic numbers, version encoding, and structure layouts are defined
-  normatively by
-  [`nanovdb/NanoVDB.h`](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/nanovdb/nanovdb/NanoVDB.h)
-  in the OpenVDB repository; this document does not restate them.
-- The buffer MUST NOT be wrapped in the `nanovdb::io` file container. That
-  container adds file-level headers and its own optional compression, both of
-  which duplicate responsibilities that belong to the Zarr chunk key and to
-  `bytes -> bytes` codecs respectively.
-- The grid's **background value** MUST equal the array's `fill_value`. This is
-  what makes inactive voxels decode correctly, and makes the meaning of
-  "inactive" identical across every chunk of the array.
+### `index_space`
 
+One of `global` or `chunk_local`: whether each chunk's grid uses the array's
+global index coordinates or is rebased to the chunk's own origin. `global` is
+REQUIRED for [grid coherence](#grid-coherence-across-chunks) and SHOULD be
+used.
 
-## Array shape contract
+### `stats`
+
+One of `none`, `bbox`, `minmax`, `all`: the per-node statistics the grid
+carries. `bbox` includes active bounding boxes; `minmax` adds per-node minimum
+and maximum values; `all` adds average and standard deviation. Empty-space
+skipping and range estimation depend on `minmax` or `all`; see
+[Reader pass-through](#reader-pass-through-non-normative).
+
+### `lossless`
+
+A boolean indicating whether decoding reproduces the encoded array exactly.
+When `true`, `tolerance` MUST be `0` and `grid_type` MUST NOT be a quantized
+type. When `false`, `tolerance` MUST be greater than `0` or `grid_type` MUST be
+a quantized type.
+
+### `tolerance`
+
+A number ≥ 0: the maximum absolute deviation from the background value at which
+the encoder may leave a voxel inactive. `0` permits dropping only voxels
+exactly equal to the background. See
+[Sparsity and losslessness](#sparsity-and-losslessness).
+
+## Supported chunk shapes
 
 The chunk MUST have exactly three spatial dimensions, optionally followed by a
-single **component dimension** for vector-valued grids. Spatial dimensions map
-to NanoVDB coordinates in C order, so that the innermost spatial dimension is
-the NanoVDB `x` axis:
+single component dimension for vector-valued grids; rank alone disambiguates
+the two forms. Spatial dimensions map to NanoVDB coordinates in C order, the
+innermost spatial dimension being the NanoVDB `x` axis:
 
-| chunk shape       | grid value  | NanoVDB coordinate of array index      |
-| ----------------- | ----------- | -------------------------------------- |
-| `[nz, ny, nx]`    | scalar      | `[k, j, i]` → `(i, j, k)`              |
-| `[nz, ny, nx, c]` | `c`-vector  | `[k, j, i, c]` → `(i, j, k)` comp. `c` |
+| chunk shape       | grid value | NanoVDB coordinate of array index      |
+| ----------------- | ---------- | -------------------------------------- |
+| `[nz, ny, nx]`    | scalar     | `[k, j, i]` → `(i, j, k)`              |
+| `[nz, ny, nx, c]` | `c`-vector | `[k, j, i, c]` → `(i, j, k)` comp. `c` |
 
-The two forms are disambiguated by rank alone: a rank-3 chunk is scalar-valued,
-a rank-4 chunk is vector-valued. The component extent `c` MUST be `3` or `4`,
-matching the vector `grid_type` (see
-[Supported data types](#supported-data-types)).
-
-The component dimension MUST be the **innermost** (unit-stride) dimension. This
-is not an arbitrary choice: NanoVDB stores a vector-valued leaf as an array of
-vectors, with a voxel's components contiguous, so an innermost component
-dimension makes the array's memory layout and the grid's identical.
+The component dimension MUST be the innermost (unit-stride) dimension, and its
+extent `c` MUST be `3` or `4` and match the vector `grid_type`. NanoVDB stores
+a voxel's vector components contiguously, so this layout makes the array's
+memory layout and the grid's identical.
 
 Encoders and decoders MUST return an error if the chunk is not one of these two
-forms, if `c` is neither `3` nor `4`, if `c` disagrees with the component count
-implied by `grid_type`, or if the grid's index bounding box is inconsistent with
-the chunk's position and spatial shape.
+forms, if `c` disagrees with `grid_type`, or if the grid's index bounding box
+is inconsistent with the chunk's position and spatial shape.
 
 Because no `array -> array` codec may precede this one (see
-[Interaction with other codecs](#interaction-with-other-codecs)), the array must
-already be laid out in one of these two forms — the layout cannot be produced by
-a preceding `transpose` or `reshape`. Arrays carrying a time axis, or more
-channels than a vector grid can hold, SHOULD place those on separate arrays so
-that each spatial volume is encoded as its own coherent grid.
+[Interaction with other codecs](#interaction-with-other-codecs)), the array
+must natively be laid out in one of these forms. Arrays carrying a time axis,
+or more channels than a vector grid can hold, SHOULD place those on separate
+arrays so that each spatial volume is encoded as its own coherent grid.
 
 These rules apply to the inner chunk shape when this codec is used as the
-array-to-bytes codec within the [`sharding_indexed`](../sharding_indexed/README.md)
-codec.
-
-## Grid coherence across chunks
-
-A NanoVDB grid is normally a *global* structure with its own index space and node
-lattice. Splitting a volume into Zarr chunks and encoding each independently
-would ordinarily destroy that: each chunk would carry an unrelated grid with its
-own origin, its own alignment, and potentially its own tree shape. Readers would
-then have to treat each chunk as an opaque volume rather than as a piece of one
-hierarchy, and no per-chunk grid could be traversed without first resolving
-where it sits.
-
-The following requirements remove that problem at the format level. An array
-using this codec MUST satisfy all of them, and a validator can check every one
-of them from the array metadata plus the chunk buffers alone.
-
-1. **One index space.** When `index_space` is `global`, each chunk's grid MUST
-   express voxel coordinates in the array's global index space — that is, a
-   voxel at array index `[k, j, i]` occupies NanoVDB coordinate `(i, j, k)`,
-   regardless of which chunk holds it. Grids MUST NOT be rebased to a
-   chunk-local origin. A reader can therefore compose the chunks of a region by
-   union, with no coordinate arithmetic, and a writer can produce them by
-   splitting one global grid.
-
-2. **Leaf-aligned chunk grid.** Every **spatial** chunk dimension MUST be an
-   integer multiple of the leaf extent implied by `tree_config` (8 for `5-4-3`),
-   and the array's chunk grid origin MUST be a multiple of that extent in each
-   spatial dimension. No leaf node may straddle a chunk boundary, so every leaf
-   belongs to exactly one chunk.
-
-3. **Node-aligned chunk shape (recommended).** Spatial chunk dimensions SHOULD
-   additionally be an integer multiple of, or an integer divisor of, the lower
-   internal node extent (128 for `5-4-3`). A chunk that is an exact node extent
-   is a clean subtree with a **dense** top level, which lets a reader address
-   the top level by direct indexing instead of searching the root node's tile
-   table. Chunk shapes that satisfy requirement 2 but not this one remain
-   conformant, at the cost of a root-level lookup per traversal.
-
-   The component dimension of a vector-valued array is exempt from requirements
-   2 and 3, and is instead governed by requirement 6.
-
-4. **Disjoint coverage.** A chunk's grid MUST contain active voxels only within
-   that chunk's bounds. Combined with requirement 1, the active set of the array
-   is exactly the disjoint union of the active sets of its chunks, and no voxel
-   is represented twice.
-
-5. **Uniform configuration.** Every chunk of an array MUST use the same
-   `grid_type`, `tree_config`, `stats`, and background value. A reader may
-   therefore specialize its traversal — including compiling a shader — once per
-   array rather than once per chunk.
-
-6. **Whole vectors per chunk.** For a vector-valued array, the chunk extent
-   along the component dimension MUST equal the array extent along it, so that
-   no chunk holds a partial vector. A voxel's components are therefore always
-   resolvable from a single chunk, and a grid never has to be assembled across
-   chunk boundaries to read one value.
-
-Requirement 3 is the only one stated as a recommendation, because the tradeoff is
-a reader-side cost rather than a correctness problem. The remaining five are
-what allow the chunks of an array to be treated as one logical grid, and a
-reader MAY rely on them without inspecting every chunk.
+array-to-bytes codec within the
+[`sharding_indexed`](../sharding_indexed/README.md) codec.
 
 ## Supported data types
 
@@ -215,7 +126,7 @@ Scalar grids take a rank-3 chunk:
 | `bool`           | `Mask`                               | Topology only; the value *is* the active mask |
 
 Vector grids take a rank-4 chunk whose innermost dimension is the component
-dimension, with extent `c` as given below:
+dimension, with extent `c`:
 
 | Zarr `data_type` | `c` | `grid_type` |
 | ---------------- | --- | ----------- |
@@ -224,114 +135,149 @@ dimension, with extent `c` as given below:
 | `float32`        | `4` | `Vec4f`     |
 | `float64`        | `4` | `Vec4d`     |
 
-This is the natural mapping for an array shaped `[Z, Y, X, C]` with `C = 3` or
-`C = 4`: the component dimension is already innermost, so the array's layout and
-the grid's are identical and no rearrangement is needed. See
-[Array shape contract](#array-shape-contract).
+Data types not listed above are supported only through promotion:
+implementations MAY promote a narrower data type to a wider `grid_type` (for
+example `uint8` or `int8` to `Int16`), but MUST record the `grid_type` actually
+written and MUST NOT promote across the scalar/vector boundary. Zarr data types
+with no NanoVDB counterpart (complex and variable-length types among them) are
+not supported.
 
-Two consequences of Zarr's `fill_value` being a scalar:
+Two NanoVDB grid families are out of scope: matrix grids, which would require
+two component dimensions (`[Z, Y, X, 3, 3]`) and therefore a revision of the
+[chunk shape rules](#supported-chunk-shapes); and integer vector grids
+(`Vec3i` and similar), a plausible future addition pending confirmation of
+which are available across the NanoVDB versions this codec targets.
+
+For vector grids, two consequences of Zarr's `fill_value` being a scalar:
 
 - The grid's background value MUST be the vector all of whose components equal
-  `fill_value`. A vector background with unequal components cannot be expressed
-  in the array metadata and MUST NOT be written.
-- A voxel is active or inactive as a whole; individual components cannot be. An
-  encoder MUST treat a voxel as non-background if *any* component differs from
-  `fill_value` by more than `tolerance`.
+  `fill_value`; a background with unequal components cannot be expressed in the
+  array metadata and MUST NOT be written.
+- A voxel is active or inactive as a whole. An encoder MUST treat a voxel as
+  non-background if *any* component differs from `fill_value` by more than
+  `tolerance`.
 
 > [!NOTE]
-> **Open question for review.** For vector grid types, the semantics of
-> `stats: minmax` are not obviously well defined, since vectors have no natural
-> total order. Componentwise minima and maxima are the plausible reading, but
-> this proposal does not yet fix it, and readers that skip subtrees by value
-> range should not assume a scalar ordering. Feedback welcome; the conservative
-> option is to restrict vector grids to `stats: none` or `stats: bbox`.
+> **Open question for review.** `stats: minmax` is not obviously well defined
+> for vector grids, which have no natural total order. Componentwise minima and
+> maxima are the plausible reading, but this proposal does not yet fix it; the
+> conservative option is to restrict vector grids to `stats: none` or `bbox`.
 
-Other data types are not supported. NanoVDB's integer vector and matrix grid
-types are candidates for a future revision, pending confirmation of which are
-available across the NanoVDB versions this codec targets.
+## Format and algorithm
 
-Implementations MAY support narrower types through promotion (for example
-`uint8` or `int8` to `Int16`), but MUST record the `grid_type` actually written.
+### Encoded representation
 
-## Sparsity and losslessness
+The encoded chunk is a single NanoVDB grid buffer: the in-memory layout
+produced by NanoVDB's grid builders, written verbatim.
+
+- The buffer MUST contain exactly one grid, MUST be little-endian, and MUST
+  begin with a valid NanoVDB grid magic number and version header. The magic
+  numbers, version encoding, and structure layouts are defined normatively by
+  [`nanovdb/NanoVDB.h`](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/nanovdb/nanovdb/NanoVDB.h);
+  this document does not restate them.
+- The buffer MUST NOT be wrapped in the `nanovdb::io` file container, whose
+  file headers and optional compression duplicate the Zarr chunk key and
+  `bytes -> bytes` codecs respectively.
+- The grid's background value MUST equal the array's `fill_value`, so that
+  inactive voxels decode identically across every chunk.
+
+### Grid coherence across chunks
+
+Encoding each chunk as an unrelated grid — its own origin, alignment, and tree
+shape — would leave readers unable to treat the chunks as parts of one
+hierarchy. The following requirements prevent that. An array using this codec
+MUST satisfy all of them, and each is checkable from the array metadata and
+chunk buffers alone.
+
+1. **One index space.** Each chunk's grid MUST express voxel coordinates in the
+   array's global index space (array index `[k, j, i]` occupies NanoVDB
+   coordinate `(i, j, k)` regardless of which chunk holds it); grids MUST NOT
+   be rebased to a chunk-local origin. Chunks of a region then compose by
+   union, and a writer can produce them by splitting one global grid.
+
+2. **Leaf-aligned chunk grid.** Every spatial chunk dimension, and the chunk
+   grid origin in each spatial dimension, MUST be an integer multiple of the
+   leaf extent implied by `tree_config` (8 for `5-4-3`), so that no leaf node
+   straddles a chunk boundary.
+
+3. **Node-aligned chunk shape (recommended).** Spatial chunk dimensions SHOULD
+   additionally be an integer multiple of, or an integer divisor of, the lower
+   internal node extent (128 for `5-4-3`). A chunk that is an exact node extent
+   is a clean subtree with a dense top level, addressable without searching the
+   root node's tile table; other shapes satisfying requirement 2 remain
+   conformant at the cost of a root-level lookup per traversal. The component
+   dimension of a vector-valued array is exempt from requirements 2 and 3 and
+   is governed by requirement 6.
+
+4. **Disjoint coverage.** A chunk's grid MUST contain active voxels only within
+   that chunk's bounds, so the array's active set is the disjoint union of its
+   chunks' active sets.
+
+5. **Uniform configuration.** Every chunk of an array MUST use the same
+   `grid_type`, `tree_config`, `stats`, and background value, letting a reader
+   specialize its traversal (including compiling a shader) once per array.
+
+6. **Whole vectors per chunk.** For a vector-valued array, the chunk extent
+   along the component dimension MUST equal the array extent along it, so that
+   no chunk holds a partial vector.
+
+Requirement 3 is a recommendation because its tradeoff is reader-side cost
+rather than correctness; the rest are what allow the chunks of an array to be
+treated as one logical grid without inspecting every chunk.
+
+### Sparsity and losslessness
 
 Decoding produces the grid's active values composited over the array's
 `fill_value`: every voxel the grid does not represent decodes as `fill_value`.
 
-Whether that round-trips exactly depends on the encoder:
-
-- With `lossless: true` and `tolerance: 0`, an encoder MUST leave a voxel
-  inactive only if its value is exactly equal to the background. Decoding then
-  reproduces the input array bit-for-bit.
+- With `lossless: true` (`tolerance: 0`), an encoder MUST leave a voxel
+  inactive only if it exactly equals the background; decoding reproduces the
+  input array bit-for-bit.
 - With `lossless: false` and `tolerance: t > 0`, an encoder MAY additionally
-  leave inactive any voxel within `t` of the background. This is the case that
-  makes the codec useful on noisy data, where a true background is rare but a
-  near-background is common — and it is a deliberate, recorded choice rather
-  than an artifact of the encoder.
-- The quantized grid types are lossy independently of `tolerance`, in the value
-  domain rather than the topology domain.
+  leave inactive any voxel within `t` of the background — the useful case for
+  noisy data, recorded in the metadata rather than left as an encoder artifact.
+- The quantized grid types are lossy in the value domain independently of
+  `tolerance`.
 
-Note that `tolerance` is a *topology* threshold, not a value threshold: voxels
-that remain active are stored at full precision (subject to `grid_type`).
-Consumers that need a defensible relationship between the stored volume and the
-original measurement should record how `tolerance` was chosen alongside the
-array.
+`tolerance` is a topology threshold, not a value threshold: voxels that remain
+active are stored at full precision (subject to `grid_type`).
 
 ## Interaction with other codecs
 
-**No `array -> array` codec may precede this codec.** There are two independent
-reasons, and the second applies even to codecs that leave the index space
-untouched:
+No `array -> array` codec may precede this codec, and implementations SHOULD
+reject such a chain when the array metadata is parsed:
 
-1. A codec that permutes or reshapes dimensions — [`transpose`](../transpose/README.md)
-   or [`reshape`](../reshape/README.md) — breaks requirement 1 of
-   [Grid coherence](#grid-coherence-across-chunks), which fixes NanoVDB
-   coordinates to array index coordinates.
-2. `array -> array` codecs are applied in reverse on read, *after* the
-   `array -> bytes` codec has been decoded. A reader that takes the pass-through
-   path described below never materializes a dense array, so there is nothing
-   for such a codec to operate on. Permitting them would make the pass-through
-   optimization unavailable for the very arrays this codec exists to serve.
-
-Implementations SHOULD reject such a codec chain when the array metadata is
-parsed, rather than at decode time. The practical consequence is that the array
-must natively be laid out as `[Z, Y, X]` or `[Z, Y, X, C]`; this codec
-deliberately does not offer a way to rearrange it.
-
-Value-domain codecs such as [`cast_value`](../cast_value/README.md) and
-[`scale_offset`](../scale_offset/README.md) are `array -> array` codecs and are
-therefore also excluded, notwithstanding that they preserve the index space.
-Where their effect is wanted, it belongs in how the array was written — noting
-in any case that they change what the background value is, and that requirement
-5 applies to the background as this codec sees it.
+1. Codecs that permute or reshape dimensions
+   ([`transpose`](../transpose/README.md), [`reshape`](../reshape/README.md))
+   break requirement 1 of [grid coherence](#grid-coherence-across-chunks),
+   which ties NanoVDB coordinates to array index coordinates.
+2. `array -> array` codecs decode *after* the `array -> bytes` codec. A reader
+   taking the pass-through path below never materializes a dense array for them
+   to operate on, so permitting them would forfeit that optimization for
+   exactly the arrays this codec serves. This excludes even value-domain codecs
+   such as [`cast_value`](../cast_value/README.md) and
+   [`scale_offset`](../scale_offset/README.md); their effect belongs in how the
+   array was written.
 
 `bytes -> bytes` codecs compose freely and are the right place for general
 compression and checksums.
 
 ## Reader pass-through (non-normative)
 
-A conventional Zarr reader will decode a chunk to a dense array, which discards
-the size advantage as soon as the chunk is in memory. Because the encoded buffer
-is already a spatial index, a reader MAY instead keep the buffer and resolve
-voxels by traversing it — the buffer is pointer-free and position-independent,
-so it can be handed to a GPU as-is and traversed in a shader.
-
-The coherence requirements above are what make this safe to do without
-inspecting the whole array: a reader can specialize its traversal once
-(requirement 5), address chunks by index without coordinate arithmetic
-(requirement 1), assume no leaf spans a boundary (requirement 2), and skip the
-root-level search entirely when requirement 3 holds.
-
-Readers doing this benefit from `stats` being `minmax` or `all`, which lets them
-skip whole subtrees whose value range falls outside the range currently of
-interest, and estimate a display range without sampling. Encoders targeting such
-readers SHOULD therefore write `minmax` or `all` rather than `none`.
+Because the encoded buffer is already a pointer-free spatial index, a reader
+MAY keep it rather than decode it to a dense array — including handing it to a
+GPU as-is and traversing it in a shader. The coherence requirements make this
+safe without inspecting the whole array: traversal is specialized once per
+array (requirement 5), chunks are addressed without coordinate arithmetic (1),
+no leaf spans a chunk boundary (2), and the root-level search can be skipped
+when requirement 3 holds. Such readers benefit from `stats` being `minmax` or
+`all`, which enables skipping subtrees outside the value range of interest;
+encoders targeting them SHOULD write those rather than `none`.
 
 ## Examples
 
-A `float32` volume stored in leaf- and node-aligned 128³ chunks, losslessly
-sparsified against a background of `0.0`, with per-node minimum and maximum
-statistics:
+A `float32` volume in leaf- and node-aligned 128³ chunks, losslessly sparsified
+against a background of `0.0`, with per-node min/max statistics:
 
 ```json
 {
@@ -359,7 +305,7 @@ statistics:
 }
 ```
 
-A segmentation mask, where only topology is stored:
+A segmentation mask, storing topology only:
 
 ```json
 {
@@ -401,8 +347,8 @@ Thresholded fluorescence, quantized and sparsified with a recorded tolerance:
 ```
 
 A sparse `float32` displacement field shaped `[Z, Y, X, C]` with `C = 3`,
-encoded as a `Vec3f` grid. Note that the component dimension is innermost and
-that the chunk shape covers it in full, so every chunk holds whole vectors:
+encoded as a `Vec3f` grid; the component dimension is innermost and covered in
+full by the chunk shape, so every chunk holds whole vectors:
 
 ```json
 {
@@ -434,22 +380,20 @@ that the chunk shape covers it in full, so every chunk holds whole vectors:
 
 TBD. Fixtures are planned alongside the reference implementation: a small
 `float32` volume and a `Mask` volume, each with a `fixtures.json` recording the
-expected decoded values and the active/inactive topology.
+expected decoded values and active/inactive topology.
 
 ## Interoperability and compatibility
 
-- The encoded buffer is a plain NanoVDB grid, so it can be read by NanoVDB
-  itself and by any tool built on it, independently of Zarr.
+- The encoded buffer is a plain NanoVDB grid, readable by NanoVDB and any tool
+  built on it, independently of Zarr.
 - Grids can be produced from OpenVDB grids with `nanovdb::createNanoGrid`, and
-  from dense arrays with NanoVDB's build tools. Note that OpenVDB's own `.vdb`
-  serialization is *not* interchangeable with a NanoVDB buffer: it is a
-  node-graph format with its own per-node compression, and must be converted.
-- Because NanoVDB buffers are versioned and self-describing, a reader can detect
-  a buffer written by a newer NanoVDB than it supports and fail cleanly.
-- Reference implementation: in progress, targeting a Zarr reader that passes the
-  buffer through to a GPU without densifying it. Not yet available; this
-  proposal is opened to solicit feedback on the coherence requirements before
-  the implementation is finalized.
+  from dense arrays with NanoVDB's build tools. OpenVDB's own `.vdb`
+  serialization is *not* interchangeable with a NanoVDB buffer and must be
+  converted.
+- NanoVDB buffers are versioned and self-describing, so a reader can detect a
+  buffer written by a newer NanoVDB than it supports and fail cleanly.
+- Reference implementation: in progress, targeting a Zarr reader that passes
+  the buffer through to a GPU without densifying it.
 
 ## Change log
 

--- a/codecs/nanovdb/README.md
+++ b/codecs/nanovdb/README.md
@@ -30,10 +30,60 @@ The value of the `name` member in the codec object MUST be `nanovdb`.
 The `configuration` object is REQUIRED and all of its members are required. It
 is a closed set: implementations MUST NOT emit members other than those below.
 
-Because a NanoVDB buffer is self-describing, decoders MUST derive grid
-geometry, grid type, and tree configuration from the buffer itself; MUST verify
-that they are consistent with the array metadata and this configuration; and
-MUST return an error on mismatch.
+A NanoVDB buffer declares its own geometry and grid type, so decoders MUST take
+those from the buffer rather than from this configuration; MUST verify that they
+are consistent with the array metadata and with the members below; and MUST
+return an error on mismatch.
+
+[`tree_config`](#tree_config) is the exception, because the buffer does not
+record it. A decoder MUST reject a declared `tree_config` it does not implement,
+and SHOULD check that the buffer's node byte spans agree with the declared
+branching factors wherever a level is non-empty.
+
+### `dimension_roles`
+
+An array of role tokens, one per dimension of **this codec's input**, outermost
+first. The input is the array chunk after any preceding `array -> array` codec
+has been applied, so when a [`transpose`](../transpose/README.md) precedes this
+codec the roles are listed in the transposed order, not the array's.
+Every dimension MUST be given a role explicitly. The codec never infers roles
+from the input's rank, from `dimension_names`, or from any convention layered
+above Zarr.
+
+| role          | how this codec encodes the dimension                                                           |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| `grid`        | Each index becomes a separate NanoVDB grid within the chunk's buffer.                          |
+| `z`, `y`, `x` | A NanoVDB coordinate axis. These three dimensions are the tree's index space.                  |
+| `channel`     | Becomes the grid's value type: extent `1` a scalar grid, `3` a `Vec3` grid, `4` a `Vec4` grid. |
+
+The roles MUST appear in this order, and encoders and decoders MUST reject any
+other arrangement:
+
+```
+[grid … grid]   z   y   x   [channel]
+```
+
+That is: zero or more `grid` dimensions, outermost; then exactly one each of
+`z`, `y` and `x`, in that order; then at most one `channel` dimension, which
+MUST be the innermost (unit-stride) dimension. A `channel` dimension MUST have
+extent `1`, `3` or `4`, matching `grid_type` per
+[Supported data types](#supported-data-types); an array with no `channel`
+dimension is scalar, exactly as one with a `channel` dimension of extent `1`.
+The strict order above constrains this codec's input, not the array. An array
+whose dimensions are in any other order reaches it through a preceding
+[`transpose`](../transpose/README.md), which is permitted for exactly this
+purpose; see
+[Interaction with other codecs](#interaction-with-other-codecs). Since
+`transpose` defines its output dimension `i` to be its input dimension
+`order[i]`, the two line up as `dimension_roles[i]` ↔ array dimension
+`order[i]` — so `order` follows from the roles the array's dimensions are meant
+to carry, and an implementation MAY derive it. OME-Zarr `[t, c, z, y, x]` with
+`c = 3` gives `order: [0, 2, 3, 4, 1]`; an `[x, y, z]` array gives
+`order: [2, 1, 0]`.
+
+Note that with a `transpose` in the chain `dimension_roles` is **not**
+index-aligned with `shape`, `chunk_shape` or `dimension_names`, which are in
+the array's own order; `order` is the only thing relating them.
 
 ### `grid_type`
 
@@ -42,7 +92,7 @@ The NanoVDB `GridType` of the encoded grid: one of `Float`, `Double`, `Int16`,
 `Vec3d`, `Vec4f`, `Vec4d`. Not redundant with the array's `data_type`: the
 quantized types (`Fp4`, `Fp8`, `Fp16`, `FpN`) encode a `float32` array in fewer
 bits per voxel, and the vector types pair a `float32` or `float64` array with a
-component dimension. See [Supported data types](#supported-data-types).
+`channel` dimension. See [Supported data types](#supported-data-types).
 
 ### `tree_config`
 
@@ -58,14 +108,28 @@ being OpenVDB's default:
 
 - It is the only one the official released NanoVDB implementation reads or
   writes.
-- A reader cannot recover the configuration from the buffer.
+- A reader cannot recover the configuration from the buffer. NanoVDB records
+  branching factors nowhere: not in the grid header, and not in the
+  `nanovdb::io` file header either, whose per-grid metadata carries node and
+  tile _counts_ rather than node dimensions. Counts do not determine the
+  `Log2Dim` values, and the arithmetic that would recover node sizes from them
+  breaks down for a level with no nodes — the sparse case this codec serves.
+  Wrapping the buffer in the file container is therefore not a way to make it
+  self-describing.
 
 The field is therefore declared explicitly rather than assumed, so that a
 reader can reject what it does not implement instead of misreading it, and so
-that another configuration can be registered later without ambiguity. Any
-future value MUST also have exactly three entries: NanoVDB's tree depth is not
-parameterized, and the [grid coherence](#grid-coherence-across-chunks)
-requirements assume the three levels above.
+that another configuration can be registered later without ambiguity. Note
+that declaring it buys a clean rejection, not compatibility: because a NanoVDB
+reader's tree type is fixed when it is compiled, no amount of metadata makes
+another configuration readable by an implementation built for this one. Keeping
+the declaration in the array metadata rather than the buffer lets a decoder
+reject an array before fetching any chunk.
+
+Any future value MUST also have exactly three entries: NanoVDB's tree depth is
+not parameterized, and the
+[grid coherence](#grid-coherence-across-chunks) requirements assume the three
+levels above.
 
 ### `index_space`
 
@@ -80,7 +144,7 @@ One of `none`, `bbox`, `minmax`, `all`: the per-node statistics the grid
 carries. `bbox` includes active bounding boxes; `minmax` adds per-node minimum
 and maximum values; `all` adds average and standard deviation. Empty-space
 skipping and range estimation depend on `minmax` or `all`; see
-[Reader pass-through](#reader-pass-through-non-normative).
+[Reader pass-through](#reader-pass-through).
 
 ### `lossless`
 
@@ -98,30 +162,33 @@ exactly equal to the background. See
 
 ## Supported chunk shapes
 
-The chunk MUST have exactly three spatial dimensions, optionally followed by a
-single component dimension for vector-valued grids; rank alone disambiguates
-the two forms. Spatial dimensions map to NanoVDB coordinates in C order, the
-innermost spatial dimension being the NanoVDB `x` axis:
+The chunk's rank MUST equal the length of
+[`dimension_roles`](#dimension_roles), and each dimension is constrained by its
+role:
 
-| chunk shape       | grid value | NanoVDB coordinate of array index      |
-| ----------------- | ---------- | -------------------------------------- |
-| `[nz, ny, nx]`    | scalar     | `[k, j, i]` → `(i, j, k)`              |
-| `[nz, ny, nx, c]` | `c`-vector | `[k, j, i, c]` → `(i, j, k)` comp. `c` |
+| role      | chunk extent                                                                                                                                |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `grid`    | Any extent. The chunk's buffer holds one grid per index, so the grid count is the product of the chunk extents along all `grid` dimensions. |
+| `z y x`   | Constrained by requirements 2 and 3 of [grid coherence](#grid-coherence-across-chunks): leaf-aligned, and node-aligned where practical.     |
+| `channel` | MUST equal the array extent along that dimension, so that no chunk holds a partial vector (requirement 6).                                  |
 
-The component dimension MUST be the innermost (unit-stride) dimension, and its
-extent `c` MUST be `3` or `4` and match the vector `grid_type`. NanoVDB stores
-a voxel's vector components contiguously, so this layout makes the array's
-memory layout and the grid's identical.
+The three spatial dimensions map to NanoVDB coordinates with the innermost
+being the `x` axis. Writing `t` for the index along a single `grid` dimension
+and `c` for the `channel` index:
 
-Encoders and decoders MUST return an error if the chunk is not one of these two
-forms, if `c` disagrees with `grid_type`, or if the grid's index bounding box
-is inconsistent with the chunk's position and spatial shape.
+| `dimension_roles`                | chunk shape           | grid value | grid within buffer | NanoVDB coordinate                                      |
+| -------------------------------- | --------------------- | ---------- | ------------------ | ------------------------------------------------------- |
+| `["z","y","x"]`                  | `[nz, ny, nx]`        | scalar     | the only grid      | `[k, j, i]` → `(i,j,k)`                                 |
+| `["z","y","x","channel"]`, `c=1` | `[nz, ny, nx, 1]`     | scalar     | the only grid      | `[k, j, i, 0]` → `(i,j,k)`                              |
+| `["z","y","x","channel"]`, `c=3` | `[nz, ny, nx, 3]`     | `Vec3`     | the only grid      | `[k, j, i, c]` → `(i,j,k)` component `c`                |
+| `["grid","z","y","x"]`           | `[nt, nz, ny, nx]`    | scalar     | grid `t`           | `[t, k, j, i]` → `(i,j,k)` in grid `t`                  |
+| `["grid","z","y","x","channel"]` | `[nt, nz, ny, nx, c]` | `c`-vector | grid `t`           | `[t, k, j, i, c]` → `(i,j,k)` component `c` in grid `t` |
 
-Because no `array -> array` codec may precede this one (see
-[Interaction with other codecs](#interaction-with-other-codecs)), the array
-must natively be laid out in one of these forms. Arrays carrying a time axis,
-or more channels than a vector grid can hold, SHOULD place those on separate
-arrays so that each spatial volume is encoded as its own coherent grid.
+Encoders and decoders MUST return an error if the roles are not in the required
+order, if the rank disagrees with `dimension_roles`, if the `channel` extent
+disagrees with `grid_type`, if the number of grids in the buffer disagrees with
+the chunk's `grid` extents, or if a grid's index bounding box is inconsistent
+with the chunk's position and spatial shape.
 
 These rules apply to the inner chunk shape when this codec is used as the
 array-to-bytes codec within the
@@ -129,7 +196,8 @@ array-to-bytes codec within the
 
 ## Supported data types
 
-Scalar grids take a rank-3 chunk:
+Scalar grids take an array with no `channel` dimension, or a `channel`
+dimension of extent `1`:
 
 | Zarr `data_type` | `grid_type`                          | Notes                                         |
 | ---------------- | ------------------------------------ | --------------------------------------------- |
@@ -141,8 +209,7 @@ Scalar grids take a rank-3 chunk:
 | `uint32`         | `UInt32`                             |                                               |
 | `bool`           | `Mask`                               | Topology only; the value _is_ the active mask |
 
-Vector grids take a rank-4 chunk whose innermost dimension is the component
-dimension, with extent `c`:
+Vector grids take a `channel` dimension of extent `c`:
 
 | Zarr `data_type` | `c` | `grid_type` |
 | ---------------- | --- | ----------- |
@@ -150,6 +217,11 @@ dimension, with extent `c`:
 | `float64`        | `3` | `Vec3d`     |
 | `float32`        | `4` | `Vec4f`     |
 | `float64`        | `4` | `Vec4d`     |
+
+A `channel` extent of `2`, or greater than `4`, has no NanoVDB counterpart and
+MUST be rejected. An axis of that width whose values belong to one voxel has no
+representation in this codec; an axis whose indices are independent fields
+SHOULD be given the `grid` role instead, which places each on its own grid.
 
 Data types not listed above are supported only through promotion:
 implementations MAY promote a narrower data type to a wider `grid_type` (for
@@ -159,8 +231,9 @@ with no NanoVDB counterpart (complex and variable-length types among them) are
 not supported.
 
 Two NanoVDB grid families are out of scope: matrix grids, which would require
-two component dimensions (`[Z, Y, X, 3, 3]`) and therefore a revision of the
-[chunk shape rules](#supported-chunk-shapes); and integer vector grids
+two `channel` dimensions (`[Z, Y, X, 3, 3]`) and therefore a revision of
+[`dimension_roles`](#dimension_roles), which permits at most one; and integer
+vector grids
 (`Vec3i` and similar), a plausible future addition pending confirmation of
 which are available across the NanoVDB versions this codec targets.
 
@@ -183,19 +256,51 @@ For vector grids, two consequences of Zarr's `fill_value` being a scalar:
 
 ### Encoded representation
 
-The encoded chunk is a single NanoVDB grid buffer: the in-memory layout
-produced by NanoVDB's grid builders, written verbatim.
+The encoded chunk is a NanoVDB grid buffer: the in-memory layout produced by
+NanoVDB's grid builders, written verbatim.
 
-- The buffer MUST contain exactly one grid, MUST be little-endian, and MUST
-  begin with a valid NanoVDB grid magic number and version header. The magic
-  numbers, version encoding, and structure layouts are defined normatively by
+- The buffer MUST be little-endian and MUST begin with a valid NanoVDB grid
+  magic number and version header. The magic numbers, version encoding, and
+  structure layouts are defined normatively by
   [`nanovdb/NanoVDB.h`](https://github.com/AcademySoftwareFoundation/openvdb/blob/master/nanovdb/nanovdb/NanoVDB.h);
   this document does not restate them.
 - The buffer MUST NOT be wrapped in the `nanovdb::io` file container, whose
   file headers and optional compression duplicate the Zarr chunk key and
-  `bytes -> bytes` codecs respectively.
-- The grid's background value MUST equal the array's `fill_value`, so that
+  `bytes -> bytes` codecs respectively. Nothing is given up by omitting it: a
+  raw grid buffer identifies itself with its own magic number, distinct from
+  the container's, and NanoVDB reads raw buffers directly — including
+  addressing one grid of a multi-grid buffer. The container's remaining fields
+  are a name lookup key and geometry that is recoverable from the grid itself.
+  It records no tree configuration either; see
+  [`tree_config`](#tree_config).
+- Every grid's background value MUST equal the array's `fill_value`, so that
   inactive voxels decode identically across every chunk.
+
+#### Grid enumeration
+
+An array whose [`dimension_roles`](#dimension_roles) contain no `grid`
+dimension encodes one grid per chunk. Otherwise the chunk's buffer holds
+`mGridCount` grids, laid out exactly as `nanovdb::mergeGrids` produces them:
+
+- The grid count MUST equal the product of the chunk's extents along its
+  `grid` dimensions, and MUST be recorded as `mGridCount` in **every** grid's
+  header, not only the first.
+- Grids MUST be stored consecutively, each beginning where the previous one
+  ends: grid `n + 1` starts `mGridSize` bytes after grid `n`. A reader locates
+  grid `n` by summing the preceding grids' `mGridSize`, which is how NanoVDB's
+  own `GridHandle` indexes a multi-grid buffer.
+- Grid `n` MUST record `mGridIndex` equal to `n`, and `n` MUST be the C-order
+  (row-major, last `grid` dimension varying fastest) ravel of the chunk-local
+  indices along the `grid` dimensions. This is what makes a grid addressable
+  from array coordinates alone.
+- `mGridName` is not authoritative: readers MUST resolve a grid by index, never
+  by name, since nothing constrains names to be unique or populated. Writers
+  MAY set names for the benefit of tools outside Zarr.
+
+Each grid is an independent tree with its own topology, so a `grid` dimension
+imposes no relationship between the active sets of successive indices — which
+is what makes it the right role for a time axis. The per-array uniformity of
+requirement 5 still applies to all of them.
 
 ### Grid coherence across chunks
 
@@ -205,38 +310,59 @@ hierarchy. The following requirements prevent that. An array using this codec
 MUST satisfy all of them, and each is checkable from the array metadata and
 chunk buffers alone.
 
-1. **One index space.** Each chunk's grid MUST express voxel coordinates in the
-   array's global index space (array index `[k, j, i]` occupies NanoVDB
-   coordinate `(i, j, k)` regardless of which chunk holds it); grids MUST NOT
-   be rebased to a chunk-local origin. Chunks of a region then compose by
-   union, and a writer can produce them by splitting one global grid.
+1. **One index space.** Each chunk's grids MUST express voxel coordinates in
+   the global index space of this codec's input (the `z`, `y`, `x` indices
+   `[k, j, i]` occupy NanoVDB coordinate `(i, j, k)` regardless of which chunk
+   holds them); grids MUST NOT be rebased to a chunk-local origin. Chunks of a
+   region then compose by union, and a writer can produce them by splitting one
+   global grid. A preceding [`transpose`](../transpose/README.md) composes a
+   constant permutation onto this mapping without weakening it: the array
+   coordinate is recovered from the NanoVDB coordinate by `order`, which is
+   metadata rather than per-chunk state.
 
-2. **Leaf-aligned chunk grid.** Every spatial chunk dimension, and the chunk
-   grid origin in each spatial dimension, MUST be an integer multiple of the
-   leaf extent `1 << tree_config[2]` (8 for `[5, 4, 3]`), so that no leaf node
-   straddles a chunk boundary.
+2. **Leaf-aligned chunk grid.** The chunk extent along each of the `z`, `y`
+   and `x` dimensions, and the chunk grid origin in each of them, MUST be an
+   integer multiple of the leaf extent `1 << tree_config[2]` (8 for
+   `[5, 4, 3]`), so that no leaf node straddles a chunk boundary.
 
-3. **Node-aligned chunk shape (recommended).** Spatial chunk dimensions SHOULD
-   additionally be an integer multiple of, or an integer divisor of, the lower
-   internal node extent `1 << (tree_config[1] + tree_config[2])` (128 for
-   `[5, 4, 3]`). A chunk that is an exact node extent
-   is a clean subtree with a dense top level, addressable without searching the
-   root node's tile table; other shapes satisfying requirement 2 remain
-   conformant at the cost of a root-level lookup per traversal. The component
-   dimension of a vector-valued array is exempt from requirements 2 and 3 and
-   is governed by requirement 6.
+3. **Node-aligned chunk shape (recommended).** The `z`, `y` and `x` chunk
+   extents SHOULD additionally be an integer multiple of, or an integer divisor
+   of, the lower internal node extent
+   `1 << (tree_config[1] + tree_config[2])` (128 for `[5, 4, 3]`). A chunk that
+   is an exact node extent is a clean subtree with a dense top level,
+   addressable without searching the root node's tile table; other shapes
+   satisfying requirement 2 remain conformant at the cost of a root-level
+   lookup per traversal.
 
-4. **Disjoint coverage.** A chunk's grid MUST contain active voxels only within
-   that chunk's bounds, so the array's active set is the disjoint union of its
-   chunks' active sets.
+   Requirements 2 and 3 constrain only the three spatial dimensions. A
+   `channel` dimension is governed by requirement 6, and a `grid` dimension by
+   requirement 7; neither has any alignment constraint, because neither is part
+   of the tree's index space. Where a `transpose` precedes this codec, the
+   extents these requirements constrain are those of the array dimensions
+   carrying the `z`, `y` and `x` roles — `chunk_shape[order[i]]` for the
+   relevant `i` — since `transpose` permutes extents without changing them.
 
-5. **Uniform configuration.** Every chunk of an array MUST use the same
-   `grid_type`, `tree_config`, `stats`, and background value, letting a reader
-   specialize its traversal (including compiling a shader) once per array.
+4. **Disjoint coverage.** Each of a chunk's grids MUST contain active voxels
+   only within that chunk's spatial bounds, so for every index along the `grid`
+   dimensions the array's active set is the disjoint union of its chunks'
+   active sets.
 
-6. **Whole vectors per chunk.** For a vector-valued array, the chunk extent
-   along the component dimension MUST equal the array extent along it, so that
-   no chunk holds a partial vector.
+5. **Uniform configuration.** Every grid of every chunk of an array MUST use
+   the same `grid_type`, `tree_config`, `stats`, and background value, letting
+   a reader specialize its traversal (including compiling a shader) once per
+   array. This is what keeps a `grid` dimension cheap: the grids differ in
+   topology and values, never in layout.
+
+6. **Whole vectors per chunk.** The chunk extent along a `channel` dimension
+   MUST equal the array extent along it, so that no chunk holds a partial
+   vector.
+
+7. **Grids addressable by index.** A chunk's grid count MUST equal the product
+   of its extents along the `grid` dimensions, and grid `n` of the buffer MUST
+   correspond to the C-order ravel of the chunk-local `grid` indices, as
+   specified in [Grid enumeration](#grid-enumeration). A reader can then map an
+   array coordinate to a grid without inspecting grid names or decoding any
+   other chunk.
 
 Requirement 3 is a recommendation because its tradeoff is reader-side cost
 rather than correctness; the rest are what allow the chunks of an array to be
@@ -261,25 +387,46 @@ active are stored at full precision (subject to `grid_type`).
 
 ## Interaction with other codecs
 
-No `array -> array` codec may precede this codec, and implementations SHOULD
-reject such a chain when the array metadata is parsed:
+[`transpose`](../transpose/README.md) is the one `array -> array` codec that may
+precede this one. No other may, and implementations SHOULD reject such a chain
+when the array metadata is parsed.
 
-1. Codecs that permute or reshape dimensions
-   ([`transpose`](../transpose/README.md), [`reshape`](../reshape/README.md))
-   break requirement 1 of [grid coherence](#grid-coherence-across-chunks),
-   which ties NanoVDB coordinates to array index coordinates.
-2. `array -> array` codecs decode _after_ the `array -> bytes` codec. A reader
-   taking the pass-through path below never materializes a dense array for them
-   to operate on, so permitting them would forfeit that optimization for
-   exactly the arrays this codec serves. This excludes even value-domain codecs
-   such as [`cast_value`](../cast_value/README.md) and
-   [`scale_offset`](../scale_offset/README.md); their effect belongs in how the
-   array was written.
+### Why `transpose` is permitted
+
+`transpose` is a pure permutation of dimension indices: rank-preserving,
+exactly invertible, and declared in full by its `order`. It therefore does not
+weaken any [grid coherence](#grid-coherence-across-chunks) requirement — the
+tie between array indices and NanoVDB coordinates is composed with a constant
+permutation rather than broken — and it is what lets a strict role order
+coexist with whatever dimension order an array wants; see
+[`dimension_roles`](#dimension_roles).
+
+The concern that applies to `array -> array` codecs in general is that they
+decode _after_ the `array -> bytes` codec, so a reader taking the pass-through
+path never materializes a dense array for them to act on. For `transpose` this
+costs nothing: the permutation is a per-array constant, so such a reader folds
+it into its coordinate mapping instead of applying it to data. This is
+normative, not merely an option — see
+[Reader pass-through](#reader-pass-through).
+
+### Why the others are not
+
+1. [`reshape`](../reshape/README.md) splits and merges dimensions, preserving
+   only C-order element order. Dimension identity does not survive it, so there
+   is no dimension for a role to describe and requirement 1 has nothing to tie
+   NanoVDB coordinates to. Combining it with `transpose` does not help: the
+   composed operation is still not a permutation.
+2. Value-domain codecs such as [`cast_value`](../cast_value/README.md) and
+   [`scale_offset`](../scale_offset/README.md) transform every voxel. Unlike a
+   permutation these cannot be folded into a coordinate mapping, so permitting
+   them would forfeit the pass-through path for exactly the arrays this codec
+   serves — and would leave a grid whose values and background do not match the
+   array's `fill_value`. Their effect belongs in how the array was written.
 
 `bytes -> bytes` codecs compose freely and are the right place for general
 compression and checksums.
 
-## Reader pass-through (non-normative)
+## Reader pass-through
 
 Because the encoded buffer is already a pointer-free spatial index, a reader
 MAY keep it rather than decode it to a dense array — including handing it to a
@@ -290,6 +437,16 @@ no leaf spans a chunk boundary (2), and the root-level search can be skipped
 when requirement 3 holds. Such readers benefit from `stats` being `minmax` or
 `all`, which enables skipping subtrees outside the value range of interest;
 encoders targeting them SHOULD write those rather than `none`.
+
+Taking this path means skipping the `array -> array` decode stage, which would
+otherwise have undone a preceding [`transpose`](../transpose/README.md). A
+reader that does so MUST compose that permutation into its own coordinate
+mapping, so that a coordinate in the array's dimension order still resolves to
+the same voxel it would have through a full decode. Since `order` is a
+per-array constant this is a relabelling of axes and not work per voxel, but
+omitting it silently returns transposed results.
+
+Everything else in this section is non-normative.
 
 ## Examples
 
@@ -309,6 +466,7 @@ against a background of `0.0`, with per-node min/max statistics:
     {
       "name": "nanovdb",
       "configuration": {
+        "dimension_roles": ["z", "y", "x"],
         "grid_type": "Float",
         "tree_config": [5, 4, 3],
         "index_space": "global",
@@ -330,6 +488,7 @@ A segmentation mask, storing topology only:
     {
       "name": "nanovdb",
       "configuration": {
+        "dimension_roles": ["z", "y", "x"],
         "grid_type": "Mask",
         "tree_config": [5, 4, 3],
         "index_space": "global",
@@ -350,6 +509,7 @@ Thresholded fluorescence, quantized and sparsified with a recorded tolerance:
     {
       "name": "nanovdb",
       "configuration": {
+        "dimension_roles": ["z", "y", "x"],
         "grid_type": "Fp16",
         "tree_config": [5, 4, 3],
         "index_space": "global",
@@ -364,7 +524,7 @@ Thresholded fluorescence, quantized and sparsified with a recorded tolerance:
 ```
 
 A sparse `float32` displacement field shaped `[Z, Y, X, C]` with `C = 3`,
-encoded as a `Vec3f` grid; the component dimension is innermost and covered in
+encoded as a `Vec3f` grid; the `channel` dimension is innermost and covered in
 full by the chunk shape, so every chunk holds whole vectors:
 
 ```json
@@ -380,6 +540,108 @@ full by the chunk shape, so every chunk holds whole vectors:
     {
       "name": "nanovdb",
       "configuration": {
+        "dimension_roles": ["z", "y", "x", "channel"],
+        "grid_type": "Vec3f",
+        "tree_config": [5, 4, 3],
+        "index_space": "global",
+        "stats": "bbox",
+        "lossless": true,
+        "tolerance": 0.0
+      }
+    },
+    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+  ]
+}
+```
+
+A time series of scalar volumes shaped `[T, Z, Y, X]`. The leading dimension
+takes the `grid` role, so each chunk's buffer holds four grids -- one per
+timepoint -- whose topologies are unrelated to each other. Nothing here is
+specific to time: the same layout serves an ensemble index or a set of
+independent fields, and `dimension_names` is where the meaning is recorded.
+
+```json
+{
+  "shape": [64, 1024, 2048, 2048],
+  "data_type": "float32",
+  "fill_value": 0.0,
+  "dimension_names": ["t", "z", "y", "x"],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": { "chunk_shape": [4, 128, 128, 128] }
+  },
+  "codecs": [
+    {
+      "name": "nanovdb",
+      "configuration": {
+        "dimension_roles": ["grid", "z", "y", "x"],
+        "grid_type": "Float",
+        "tree_config": [5, 4, 3],
+        "index_space": "global",
+        "stats": "minmax",
+        "lossless": true,
+        "tolerance": 0.0
+      }
+    },
+    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+  ]
+}
+```
+
+The same volumes with a three-component vector value per voxel, shaped
+`[T, Z, Y, X, C]`: `grid` outermost, `channel` innermost, and the chunk covers
+the `channel` dimension in full.
+
+```json
+{
+  "shape": [64, 1024, 2048, 2048, 3],
+  "data_type": "float32",
+  "fill_value": 0.0,
+  "dimension_names": ["t", "z", "y", "x", "c"],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": { "chunk_shape": [4, 128, 128, 128, 3] }
+  },
+  "codecs": [
+    {
+      "name": "nanovdb",
+      "configuration": {
+        "dimension_roles": ["grid", "z", "y", "x", "channel"],
+        "grid_type": "Vec3f",
+        "tree_config": [5, 4, 3],
+        "index_space": "global",
+        "stats": "bbox",
+        "lossless": true,
+        "tolerance": 0.0
+      }
+    },
+    { "name": "zstd", "configuration": { "level": 3, "checksum": false } }
+  ]
+}
+```
+
+An OME-Zarr style array shaped `[T, C, Z, Y, X]` with `C = 3`, whose three
+components belong to one voxel. A `transpose` moves the channel axis innermost
+so that this codec's input is `[t, z, y, x, c]`; each timepoint becomes one
+`Vec3f` grid. Note that `dimension_names` is in the array's order while
+`dimension_roles` is in the transposed order, and `order` relates them:
+
+```json
+{
+  "shape": [64, 3, 1024, 2048, 2048],
+  "data_type": "float32",
+  "fill_value": 0.0,
+  "dimension_names": ["t", "c", "z", "y", "x"],
+  "chunk_grid": {
+    "name": "regular",
+    "configuration": { "chunk_shape": [4, 3, 128, 128, 128] }
+  },
+  "codecs": [
+    { "name": "transpose", "configuration": { "order": [0, 2, 3, 4, 1] } },
+    {
+      "name": "nanovdb",
+      "configuration": {
+        "dimension_roles": ["grid", "z", "y", "x", "channel"],
         "grid_type": "Vec3f",
         "tree_config": [5, 4, 3],
         "index_space": "global",
@@ -402,13 +664,20 @@ expected decoded values and active/inactive topology.
 ## Interoperability and compatibility
 
 - The encoded buffer is a plain NanoVDB grid, readable by NanoVDB and any tool
-  built on it, independently of Zarr.
+  built on it, independently of Zarr — once the `bytes -> bytes` stage has been
+  undone. Since compression is both recommended and effective here, a stored
+  chunk is generally not a NanoVDB buffer as it sits: reaching one means
+  running the Zarr decode chain, or writing the array with no `bytes -> bytes`
+  codec.
 - Grids can be produced from OpenVDB grids with `nanovdb::createNanoGrid`, and
   from dense arrays with NanoVDB's build tools. OpenVDB's own `.vdb`
   serialization is _not_ interchangeable with a NanoVDB buffer and must be
   converted.
-- NanoVDB buffers are versioned and self-describing, so a reader can detect a
-  buffer written by a newer NanoVDB than it supports and fail cleanly.
+- NanoVDB buffers carry a version and declare their grid type, so a reader can
+  detect a buffer written by a newer NanoVDB, or holding a value type it does
+  not handle, and fail cleanly. They are not self-describing about the tree
+  configuration, which is why [`tree_config`](#tree_config) is recorded in the
+  array metadata.
 - Reference implementation: in progress, targeting a Zarr reader that passes
   the buffer through to a GPU without densifying it.
 

--- a/codecs/nanovdb/schema.json
+++ b/codecs/nanovdb/schema.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "const": "nanovdb"
+    },
+    "configuration": {
+      "type": "object",
+      "description": "NanoVDB encoding parameters, recorded so the encoding is deliberate and reproducible across the chunks of an array. Decoders MUST derive grid geometry, grid type, and tree configuration from the buffer itself and MUST NOT rely on these members to parse it, but MUST verify consistency with them and with the array metadata.",
+      "properties": {
+        "grid_type": {
+          "type": "string",
+          "enum": [
+            "Float",
+            "Double",
+            "Int16",
+            "Int32",
+            "Int64",
+            "UInt32",
+            "Mask",
+            "Fp4",
+            "Fp8",
+            "Fp16",
+            "FpN",
+            "Vec3f",
+            "Vec3d",
+            "Vec4f",
+            "Vec4d"
+          ],
+          "description": "NanoVDB GridType of the encoded grid. Not redundant with the array data_type: Fp4, Fp8, Fp16, and FpN encode a float32 array at reduced precision, and the Vec types pair a float32 or float64 array with an innermost component dimension of extent 3 or 4."
+        },
+        "tree_config": {
+          "type": "string",
+          "const": "5-4-3",
+          "description": "Node branching factors as Log2Dim values from root side to leaf. 5-4-3 is OpenVDB's default: 8^3 leaves, 128^3 lower internal nodes, 4096^3 upper internal nodes."
+        },
+        "index_space": {
+          "type": "string",
+          "enum": ["global", "chunk_local"],
+          "description": "Whether each chunk's grid uses the array's global index coordinates or is rebased to the chunk origin. 'global' is required for cross-chunk grid coherence."
+        },
+        "stats": {
+          "type": "string",
+          "enum": ["none", "bbox", "minmax", "all"],
+          "description": "Per-node statistics carried by the grid. 'bbox' includes active bounding boxes, 'minmax' adds per-node minimum and maximum, 'all' adds average and standard deviation."
+        },
+        "lossless": {
+          "type": "boolean",
+          "description": "Whether decoding reproduces the encoded array exactly. When true, tolerance MUST be 0 and grid_type MUST NOT be a quantized type."
+        },
+        "tolerance": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum absolute deviation from the background value at which the encoder may leave a voxel inactive. 0 means only voxels exactly equal to the background may be dropped. This is a topology threshold, not a value threshold."
+        }
+      },
+      "required": [
+        "grid_type",
+        "tree_config",
+        "index_space",
+        "stats",
+        "lossless",
+        "tolerance"
+      ],
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": { "lossless": { "const": true } },
+            "required": ["lossless"]
+          },
+          "then": {
+            "properties": {
+              "tolerance": { "const": 0 },
+              "grid_type": {
+                "not": { "enum": ["Fp4", "Fp8", "Fp16", "FpN"] }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "lossless": { "const": false } },
+            "required": ["lossless"]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "properties": { "tolerance": { "exclusiveMinimum": 0 } },
+                "required": ["tolerance"]
+              },
+              {
+                "properties": {
+                  "grid_type": { "enum": ["Fp4", "Fp8", "Fp16", "FpN"] }
+                },
+                "required": ["grid_type"]
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "required": ["name", "configuration"],
+  "additionalProperties": false
+}

--- a/codecs/nanovdb/schema.json
+++ b/codecs/nanovdb/schema.json
@@ -49,6 +49,7 @@
             "Int16",
             "Int32",
             "Int64",
+            "UInt8",
             "UInt32",
             "Mask",
             "Fp4",
@@ -58,9 +59,10 @@
             "Vec3f",
             "Vec3d",
             "Vec4f",
-            "Vec4d"
+            "Vec4d",
+            "RGBA8"
           ],
-          "description": "NanoVDB GridType of the encoded grid. Not redundant with the array data_type: Fp4, Fp8, Fp16, and FpN encode a float32 array at reduced precision, and the Vec types pair a float32 or float64 array with a 'channel' dimension of extent 3 or 4."
+          "description": "NanoVDB GridType of the encoded grid. Not redundant with the array data_type: Fp4, Fp8, Fp16, and FpN encode a float32 array at reduced precision, the Vec types pair a float32 or float64 array with a 'channel' dimension of extent 3 or 4, and RGBA8 packs a uint8 'channel' dimension of extent 3 or 4 into one 32-bit word with red in the lowest byte."
         },
         "tree_config": {
           "type": "array",

--- a/codecs/nanovdb/schema.json
+++ b/codecs/nanovdb/schema.json
@@ -32,9 +32,15 @@
           "description": "NanoVDB GridType of the encoded grid. Not redundant with the array data_type: Fp4, Fp8, Fp16, and FpN encode a float32 array at reduced precision, and the Vec types pair a float32 or float64 array with an innermost component dimension of extent 3 or 4."
         },
         "tree_config": {
-          "type": "string",
-          "const": "5-4-3",
-          "description": "Node branching factors as Log2Dim values from root side to leaf. 5-4-3 is OpenVDB's default: 8^3 leaves, 128^3 lower internal nodes, 4096^3 upper internal nodes."
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "minItems": 3,
+          "maxItems": 3,
+          "const": [5, 4, 3],
+          "description": "Node branching factors as the Log2Dim of each level from the root side to the leaf. [5, 4, 3] is the only registered configuration: 8^3 leaves, 128^3 lower internal nodes, 4096^3 upper internal nodes. It is the only configuration any released NanoVDB implementation reads or writes, and a reader cannot recover the configuration from the buffer, so a wrong assumption is a silent misread. Any future value must also have exactly three entries; NanoVDB's tree depth is not parameterized."
         },
         "index_space": {
           "type": "string",

--- a/codecs/nanovdb/schema.json
+++ b/codecs/nanovdb/schema.json
@@ -83,24 +83,13 @@
           "const": [5, 4, 3],
           "description": "Node branching factors as the Log2Dim of each level from the root side to the leaf. [5, 4, 3] is the only registered configuration: 8^3 leaves, 128^3 lower internal nodes, 4096^3 upper internal nodes. It is the only configuration any released NanoVDB implementation reads or writes, and a reader cannot recover the configuration from the buffer, so a wrong assumption is a silent misread. Any future value must also have exactly three entries; NanoVDB's tree depth is not parameterized."
         },
-        "index_space": {
-          "type": "string",
-          "enum": ["global", "chunk_local"],
-          "description": "Whether each chunk's grid uses the array's global index coordinates or is rebased to the chunk origin. 'global' is required for cross-chunk grid coherence."
-        },
         "stats": {
           "type": "string",
           "enum": ["none", "bbox", "minmax", "all"],
           "description": "Per-node statistics carried by the grid. 'bbox' includes active bounding boxes, 'minmax' adds per-node minimum and maximum, 'all' adds average and standard deviation."
         }
       },
-      "required": [
-        "dimension_roles",
-        "grid_type",
-        "tree_config",
-        "index_space",
-        "stats"
-      ],
+      "required": ["dimension_roles", "grid_type", "tree_config", "stats"],
       "additionalProperties": false
     }
   },

--- a/codecs/nanovdb/schema.json
+++ b/codecs/nanovdb/schema.json
@@ -8,8 +8,39 @@
     },
     "configuration": {
       "type": "object",
-      "description": "NanoVDB encoding parameters, recorded so the encoding is deliberate and reproducible across the chunks of an array. Decoders MUST derive grid geometry, grid type, and tree configuration from the buffer itself and MUST NOT rely on these members to parse it, but MUST verify consistency with them and with the array metadata.",
+      "description": "NanoVDB encoding parameters, recorded so the encoding is deliberate and reproducible across the chunks of an array. Decoders MUST derive grid geometry and grid type from the buffer itself and MUST NOT rely on these members to parse it, but MUST verify consistency with them and with the array metadata. tree_config is the exception: the buffer does not record branching factors, so a decoder must reject a configuration it does not implement.",
       "properties": {
+        "dimension_roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["grid", "z", "y", "x", "channel"]
+          },
+          "minItems": 3,
+          "allOf": [
+            {
+              "contains": { "const": "z" },
+              "minContains": 1,
+              "maxContains": 1
+            },
+            {
+              "contains": { "const": "y" },
+              "minContains": 1,
+              "maxContains": 1
+            },
+            {
+              "contains": { "const": "x" },
+              "minContains": 1,
+              "maxContains": 1
+            },
+            {
+              "contains": { "const": "channel" },
+              "minContains": 0,
+              "maxContains": 1
+            }
+          ],
+          "description": "How this codec encodes each dimension of its input, one token per dimension, outermost first. The input is the array chunk after any preceding array -> array codec, so when a 'transpose' precedes this codec the roles are in the transposed order and are NOT index-aligned with the array's shape or dimension_names. 'grid' dimensions are enumerated across grids within the chunk's buffer; 'z', 'y' and 'x' are the tree's coordinate axes; 'channel' becomes the grid value type (extent 1 scalar, 3 Vec3, 4 Vec4). The tokens MUST appear in the order: zero or more 'grid', then 'z', 'y', 'x', then at most one 'channel' as the innermost dimension. JSON Schema can express the multiplicities but not that ordering, which is normative in the README. The roles say only how the codec processes a dimension and assert nothing about what it means."
+        },
         "grid_type": {
           "type": "string",
           "enum": [
@@ -29,7 +60,7 @@
             "Vec4f",
             "Vec4d"
           ],
-          "description": "NanoVDB GridType of the encoded grid. Not redundant with the array data_type: Fp4, Fp8, Fp16, and FpN encode a float32 array at reduced precision, and the Vec types pair a float32 or float64 array with an innermost component dimension of extent 3 or 4."
+          "description": "NanoVDB GridType of the encoded grid. Not redundant with the array data_type: Fp4, Fp8, Fp16, and FpN encode a float32 array at reduced precision, and the Vec types pair a float32 or float64 array with a 'channel' dimension of extent 3 or 4."
         },
         "tree_config": {
           "type": "array",
@@ -63,6 +94,7 @@
         }
       },
       "required": [
+        "dimension_roles",
         "grid_type",
         "tree_config",
         "index_space",

--- a/codecs/nanovdb/schema.json
+++ b/codecs/nanovdb/schema.json
@@ -8,7 +8,7 @@
     },
     "configuration": {
       "type": "object",
-      "description": "NanoVDB encoding parameters, recorded so the encoding is deliberate and reproducible across the chunks of an array. Decoders MUST derive grid geometry and grid type from the buffer itself and MUST NOT rely on these members to parse it, but MUST verify consistency with them and with the array metadata. tree_config is the exception: the buffer does not record branching factors, so a decoder must reject a configuration it does not implement.",
+      "description": "NanoVDB encoding parameters, recorded so the encoding is deliberate and reproducible across the chunks of an array. Decoders MUST derive grid geometry and grid type from the buffer itself and MUST NOT rely on these members to parse it, but MUST verify consistency with them and with the array metadata. tree_config is the exception: the buffer does not record branching factors, so a decoder must reject a configuration it does not implement. A voxel is active if and only if its value differs from the array's fill_value, so the active set is fully determined by the data and needs no configuration.",
       "properties": {
         "dimension_roles": {
           "type": "array",
@@ -19,22 +19,30 @@
           "minItems": 3,
           "allOf": [
             {
-              "contains": { "const": "z" },
+              "contains": {
+                "const": "z"
+              },
               "minContains": 1,
               "maxContains": 1
             },
             {
-              "contains": { "const": "y" },
+              "contains": {
+                "const": "y"
+              },
               "minContains": 1,
               "maxContains": 1
             },
             {
-              "contains": { "const": "x" },
+              "contains": {
+                "const": "x"
+              },
               "minContains": 1,
               "maxContains": 1
             },
             {
-              "contains": { "const": "channel" },
+              "contains": {
+                "const": "channel"
+              },
               "minContains": 0,
               "maxContains": 1
             }
@@ -84,15 +92,6 @@
           "type": "string",
           "enum": ["none", "bbox", "minmax", "all"],
           "description": "Per-node statistics carried by the grid. 'bbox' includes active bounding boxes, 'minmax' adds per-node minimum and maximum, 'all' adds average and standard deviation."
-        },
-        "lossless": {
-          "type": "boolean",
-          "description": "Whether decoding reproduces the encoded array exactly. When true, tolerance MUST be 0 and grid_type MUST NOT be a quantized type."
-        },
-        "tolerance": {
-          "type": "number",
-          "minimum": 0,
-          "description": "Maximum absolute deviation from the background value at which the encoder may leave a voxel inactive. 0 means only voxels exactly equal to the background may be dropped. This is a topology threshold, not a value threshold."
         }
       },
       "required": [
@@ -100,47 +99,9 @@
         "grid_type",
         "tree_config",
         "index_space",
-        "stats",
-        "lossless",
-        "tolerance"
+        "stats"
       ],
-      "additionalProperties": false,
-      "allOf": [
-        {
-          "if": {
-            "properties": { "lossless": { "const": true } },
-            "required": ["lossless"]
-          },
-          "then": {
-            "properties": {
-              "tolerance": { "const": 0 },
-              "grid_type": {
-                "not": { "enum": ["Fp4", "Fp8", "Fp16", "FpN"] }
-              }
-            }
-          }
-        },
-        {
-          "if": {
-            "properties": { "lossless": { "const": false } },
-            "required": ["lossless"]
-          },
-          "then": {
-            "anyOf": [
-              {
-                "properties": { "tolerance": { "exclusiveMinimum": 0 } },
-                "required": ["tolerance"]
-              },
-              {
-                "properties": {
-                  "grid_type": { "enum": ["Fp4", "Fp8", "Fp16", "FpN"] }
-                },
-                "required": ["grid_type"]
-              }
-            ]
-          }
-        }
-      ]
+      "additionalProperties": false
     }
   },
   "required": ["name", "configuration"],


### PR DESCRIPTION
This is a draft codec for a array>bytes codec for storing image data in a nanovdb buffer.

This is intended to allow zarr to better support imaging data that is sparse.  [Nanovdb](https://developer.nvidia.com/nanovdb) is an industry tested GPU friendly format that is part of the larger openvdb ecosystem for storing sparse imaging data in a shallow tree data structure that allows efficient graphics operations.  As such, there are many rendering engines that can support loading nanovdb buffers directly into the GPU. I've had success with a prototype of writing nanovdb encoded zarr to visualize large scale imaging data in neuroglancer, so I thought I'd open this PR to trigger a broader community discussion. 

I've made a [prototype zarr plugin](https://github.com/AllenInstitute/zarr-nanovdb)

and a [prototype neuroglancer reader](https://github.com/AllenInstitute/neuroglancer/tree/zarr-nanovdb)

with a test deployment here
https://ng-nanovdb-dot-em-270621.wm.r.appspot.com/

I have used this to write a couple prototype volumes that I think are showing a lot of promise.

First is a synthetic float32 dataset with 3 different resolution zarr's, 200k^3, 50k^3, and 10k^3, each with 2k x 2k x 2k chunks.  This would be 34PB raw, but i sparsely populated it with 300 artificial stars, complete with planets and 1 pixel moons. It condenses down to 1.8GB after nanovdb and zstd compression. [This renders quite nicely on the neuroglancer branch](https://tinyurl.com/4zp4zvnt), whereas a dense format would have struggled to load a 10k^3 dense buffer into GPU ram.  **HINT: zoom in within pinch or ctrl+scroll :)**

The second is a fluorescence microscopy dataset that I converted MIP2 - 5.  So the volume is 7k x 7k x 15k, a naive 3.2TB at float32.  Masking out the dim pixels allowed me to shrink this to 579MB on disk, and 15GB in decompressed RAM.

[neuroglancer link](https://tinyurl.com/4fj5b56d)

Chunking the zarr it small enough to get similar wins by having enough empty chunks would have resulted in many chunks and some careful tuning of chunk size relative to the data density.  Especially in the microscopy dataset where the data density is highly non-uniform this would not really have been a fruitful strategy. The nanovdb approach scales much more naturally, plus I can simply load the nanovdb buffer into the GPU as is and begin rendering it without inflating it back to a dense representation (although a reader is free to do that as well).  

Of course, this is all predicated on the user having a clear idea about what voxels they are willing to discard, but I think using this codec is predicated on your data being sparse in some meaningful way.

<img width="3593" height="1787" alt="neuroglancer-screenshot-w3593px-h1787px-at-9_6_2026-1_34_29 PM" src="https://github.com/user-attachments/assets/2ad9109b-fc61-49b1-a62a-66cf11227d06" />

